### PR TITLE
Bring over Erlang frontend from Lumen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
 
 members = [
+    "diagnostics",
+    "frontend",
     "compiler",
     "pattern-compiler",
     "util",

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018 Paul Schoenfelder
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/diagnostics/Cargo.toml
+++ b/diagnostics/Cargo.toml
@@ -3,6 +3,7 @@ name = "diagnostics"
 version = "0.1.0"
 authors = ["Paul Schoenfelder <paulschoenfelder@gmail.com>", "Luke Imhoff <Kronic.Deth@gmail.com>"]
 edition = "2018"
+license = "../LICENSE.md"
 
 [dependencies]
 termcolor = "0.3"

--- a/diagnostics/Cargo.toml
+++ b/diagnostics/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "diagnostics"
+version = "0.1.0"
+authors = ["Paul Schoenfelder <paulschoenfelder@gmail.com>", "Luke Imhoff <Kronic.Deth@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+termcolor = "0.3"
+failure = "0.1"
+itertools = "0.8"
+unicode-width = "0.1"
+
+[dev-dependencies]
+pretty_assertions = "0.5"

--- a/diagnostics/src/diagnostics.rs
+++ b/diagnostics/src/diagnostics.rs
@@ -1,0 +1,20 @@
+//! This is a forked version of `codespan` and `codespan-reporting` vendored into this project:
+//!
+//! * [codespan](https://github.com/brendanzab/codespan)
+//!
+//! Utilities for working with source code and printing nicely formatted
+//! diagnostic information like warnings and errors.
+mod codemap;
+mod filemap;
+mod index;
+mod span;
+
+pub use self::codemap::CodeMap;
+pub use self::filemap::{ByteIndexError, LineIndexError, LocationError, SpanError};
+pub use self::filemap::{FileMap, FileName};
+pub use self::index::{ByteIndex, ByteOffset};
+pub use self::index::{ColumnIndex, ColumnNumber, ColumnOffset};
+pub use self::index::{Index, Offset};
+pub use self::index::{LineIndex, LineNumber, LineOffset};
+pub use self::index::{RawIndex, RawOffset};
+pub use self::span::{ByteSpan, Span, DUMMY_SPAN};

--- a/diagnostics/src/diagnostics/codemap.rs
+++ b/diagnostics/src/diagnostics/codemap.rs
@@ -1,0 +1,180 @@
+use std::io;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use itertools::Itertools;
+
+use super::filemap::{FileMap, FileName};
+use super::index::{ByteIndex, ByteOffset, RawIndex};
+
+#[derive(Clone, Debug, Default)]
+pub struct CodeMap {
+    files: Vec<Arc<FileMap>>,
+}
+impl CodeMap {
+    /// Creates an empty `CodeMap`.
+    pub fn new() -> CodeMap {
+        CodeMap::default()
+    }
+
+    /// The next start index to use for a new filemap
+    fn next_start_index(&self) -> ByteIndex {
+        let end_index = self
+            .files
+            .last()
+            .map(|x| x.span().end())
+            .unwrap_or_else(ByteIndex::none);
+
+        // Add one byte of padding between each file
+        end_index + ByteOffset(1)
+    }
+
+    /// Adds a filemap to the codemap with the given name and source item
+    pub fn add_filemap<S>(&mut self, name: FileName, src: S) -> Arc<FileMap>
+    where
+        S: AsRef<str>,
+    {
+        let file = Arc::new(FileMap::with_index(
+            name,
+            src.as_ref().to_owned(),
+            self.next_start_index(),
+        ));
+        self.files.push(file.clone());
+        file
+    }
+
+    /// Adds a filemap to the codemap with the given name and source string
+    pub fn add_filemap_from_string(&mut self, name: FileName, src: String) -> Arc<FileMap> {
+        let file = Arc::new(FileMap::with_index(name, src, self.next_start_index()));
+        self.files.push(file.clone());
+        file
+    }
+
+    /// Adds a filemap to the codemap with the given name and source string
+    pub fn add_filemap_from_disk<P: Into<PathBuf>>(&mut self, name: P) -> io::Result<Arc<FileMap>> {
+        let file = Arc::new(FileMap::from_disk(name, self.next_start_index())?);
+        self.files.push(file.clone());
+        Ok(file)
+    }
+
+    /// Looks up the `File` that contains the specified byte index.
+    pub fn find_file(&self, index: ByteIndex) -> Option<&Arc<FileMap>> {
+        self.find_index(index).map(|i| &self.files[i])
+    }
+
+    pub fn update(&mut self, index: ByteIndex, src: String) -> Option<Arc<FileMap>> {
+        self.find_index(index).map(|i| {
+            let min = if i == 0 {
+                ByteIndex(1)
+            } else {
+                self.files[i - 1].span().end() + ByteOffset(1)
+            };
+            let max = self
+                .files
+                .get(i + 1)
+                .map_or(ByteIndex(RawIndex::max_value()), |file_map| {
+                    file_map.span().start()
+                })
+                - ByteOffset(1);
+            if src.len() <= (max - min).to_usize() {
+                let start_index = self.files[i].span().start();
+                let name = self.files[i].name().clone();
+                let new_file = Arc::new(FileMap::with_index(name, src, start_index));
+                self.files[i] = new_file.clone();
+                new_file
+            } else {
+                let file = self.files.remove(i);
+                match self
+                    .files
+                    .first()
+                    .map(|file| file.span().start().to_usize() - 1)
+                    .into_iter()
+                    .chain(self.files.iter().tuple_windows().map(|(x, y)| {
+                        eprintln!("{} {}", x.span(), y.span());
+                        (y.span().start() - x.span().end()).to_usize() - 1
+                    }))
+                    .position(|size| size >= src.len() + 1)
+                {
+                    Some(j) => {
+                        let start_index = if j == 0 {
+                            ByteIndex(1)
+                        } else {
+                            self.files[j - 1].span().end() + ByteOffset(1)
+                        };
+                        let new_file =
+                            Arc::new(FileMap::with_index(file.name().clone(), src, start_index));
+                        self.files.insert(j, new_file.clone());
+                        new_file
+                    }
+                    None => self.add_filemap(file.name().clone(), src),
+                }
+            }
+        })
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Arc<FileMap>> {
+        self.files.iter()
+    }
+
+    fn find_index(&self, index: ByteIndex) -> Option<usize> {
+        use std::cmp::Ordering;
+
+        self.files
+            .binary_search_by(|file| match () {
+                () if file.span().start() > index => Ordering::Greater,
+                () if file.span().end() < index => Ordering::Less,
+                () => Ordering::Equal,
+            })
+            .ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::diagnostics::index::{ByteIndex, RawIndex};
+    use crate::diagnostics::span::Span;
+
+    fn check_maps(code_map: &CodeMap, files: &[(RawIndex, &str, &str)]) {
+        println!("{:?}", code_map);
+        assert_eq!(code_map.files.len(), files.len());
+        let mut prev_span = Span::new(0.into(), 0.into());
+        for (i, (file, &(start, name, src))) in code_map.files.iter().zip(files).enumerate() {
+            println!("{}: {:?} <=> {:?}", i, file, (start, name, src));
+            match *file.name() {
+                FileName::Virtual(ref virt) => assert_eq!(*virt, name, "At index {}", i),
+                _ => panic!(),
+            }
+            assert_eq!(ByteIndex(start), file.span().start(), "At index {}", i);
+            assert!(prev_span.end() < file.span().start(), "At index {}", i);
+            assert_eq!(file.src(), src, "At index {}", i);
+
+            prev_span = file.span();
+        }
+    }
+
+    #[test]
+    fn update() {
+        let mut code_map = CodeMap::new();
+
+        let a_span = code_map
+            .add_filemap_from_string("a".into(), "a".into())
+            .span();
+        let b_span = code_map
+            .add_filemap_from_string("b".into(), "b".into())
+            .span();
+        let c_span = code_map
+            .add_filemap_from_string("c".into(), "c".into())
+            .span();
+
+        code_map.update(a_span.start(), "aa".into()).unwrap();
+        check_maps(&code_map, &[(3, "b", "b"), (5, "c", "c"), (7, "a", "aa")]);
+
+        code_map.update(b_span.start(), "".into()).unwrap().span();
+        check_maps(&code_map, &[(3, "b", ""), (5, "c", "c"), (7, "a", "aa")]);
+
+        code_map.update(c_span.start(), "ccc".into()).unwrap();
+        check_maps(&code_map, &[(3, "b", ""), (7, "a", "aa"), (10, "c", "ccc")]);
+    }
+}

--- a/diagnostics/src/diagnostics/filemap.rs
+++ b/diagnostics/src/diagnostics/filemap.rs
@@ -1,0 +1,587 @@
+//! Various source mapping utilities
+
+use std::borrow::Cow;
+use std::path::{Path, PathBuf};
+use std::{fmt, io};
+
+use failure::Fail;
+
+use super::index::{
+    ByteIndex, ByteOffset, ColumnIndex, LineIndex, LineOffset, RawIndex, RawOffset,
+};
+use super::span::ByteSpan;
+
+use unicode_width::UnicodeWidthChar;
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum FileName {
+    /// A real file on disk
+    Real(PathBuf),
+    /// A synthetic file, eg. from the REPL
+    Virtual(Cow<'static, str>),
+}
+
+impl From<PathBuf> for FileName {
+    fn from(name: PathBuf) -> FileName {
+        FileName::real(name)
+    }
+}
+
+impl From<FileName> for PathBuf {
+    fn from(name: FileName) -> PathBuf {
+        match name {
+            FileName::Real(path) => path,
+            FileName::Virtual(Cow::Owned(owned)) => PathBuf::from(owned),
+            FileName::Virtual(Cow::Borrowed(borrowed)) => PathBuf::from(borrowed),
+        }
+    }
+}
+
+impl<'a> From<&'a FileName> for &'a Path {
+    fn from(name: &'a FileName) -> &'a Path {
+        match *name {
+            FileName::Real(ref path) => path,
+            FileName::Virtual(ref cow) => Path::new(cow.as_ref()),
+        }
+    }
+}
+
+impl<'a> From<&'a Path> for FileName {
+    fn from(name: &Path) -> FileName {
+        FileName::real(name)
+    }
+}
+
+impl From<String> for FileName {
+    fn from(name: String) -> FileName {
+        FileName::virtual_(name)
+    }
+}
+
+impl From<&'static str> for FileName {
+    fn from(name: &'static str) -> FileName {
+        FileName::virtual_(name)
+    }
+}
+
+impl AsRef<Path> for FileName {
+    fn as_ref(&self) -> &Path {
+        match *self {
+            FileName::Real(ref path) => path.as_ref(),
+            FileName::Virtual(ref cow) => Path::new(cow.as_ref()),
+        }
+    }
+}
+
+impl PartialEq<Path> for FileName {
+    fn eq(&self, other: &Path) -> bool {
+        self.as_ref() == other
+    }
+}
+
+impl PartialEq<PathBuf> for FileName {
+    fn eq(&self, other: &PathBuf) -> bool {
+        self.as_ref() == other.as_path()
+    }
+}
+
+impl FileName {
+    pub fn real<T: Into<PathBuf>>(name: T) -> FileName {
+        FileName::Real(name.into())
+    }
+
+    pub fn virtual_<T: Into<Cow<'static, str>>>(name: T) -> FileName {
+        FileName::Virtual(name.into())
+    }
+
+    pub fn to_string(&self) -> String {
+        match *self {
+            FileName::Real(ref path) => match path.to_str() {
+                None => path.to_string_lossy().into_owned(),
+                Some(s) => s.to_owned(),
+            },
+            FileName::Virtual(ref s) => s.clone().into_owned(),
+        }
+    }
+}
+
+impl fmt::Display for FileName {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            FileName::Real(ref path) => write!(fmt, "{}", path.display()),
+            FileName::Virtual(ref name) => write!(fmt, "<{}>", name),
+        }
+    }
+}
+
+#[derive(Debug, Fail, PartialEq)]
+pub enum LineIndexError {
+    #[fail(display = "Line out of bounds - given: {:?}, max: {:?}", given, max)]
+    OutOfBounds { given: LineIndex, max: LineIndex },
+}
+
+#[derive(Debug, Fail, PartialEq)]
+pub enum ByteIndexError {
+    #[fail(
+        display = "Byte index out of bounds - given: {}, span: {}",
+        given, span
+    )]
+    OutOfBounds { given: ByteIndex, span: ByteSpan },
+    #[fail(
+        display = "Byte index points within a character boundary - given: {}",
+        given
+    )]
+    InvalidCharBoundary { given: ByteIndex },
+}
+
+#[derive(Debug, Fail, PartialEq)]
+pub enum LocationError {
+    #[fail(display = "Line out of bounds - given: {:?}, max: {:?}", given, max)]
+    LineOutOfBounds { given: LineIndex, max: LineIndex },
+    #[fail(display = "Column out of bounds - given: {:?}, max: {:?}", given, max)]
+    ColumnOutOfBounds {
+        given: ColumnIndex,
+        max: ColumnIndex,
+    },
+}
+
+#[derive(Debug, Fail, PartialEq)]
+pub enum SpanError {
+    #[fail(display = "Span out of bounds - given: {}, span: {}", given, span)]
+    OutOfBounds { given: ByteSpan, span: ByteSpan },
+}
+
+#[derive(Debug)]
+/// Some source code
+pub struct FileMap {
+    /// The name of the file that the source came from
+    pub name: FileName,
+    /// The complete source code
+    pub src: String,
+    /// The span of the source in the `CodeMap`
+    span: ByteSpan,
+    /// Offsets to the line beginnings in the source
+    lines: Vec<ByteOffset>,
+}
+
+impl FileMap {
+    /// Read some source code from a file, loading it into a filemap
+    pub(crate) fn from_disk<P: Into<PathBuf>>(name: P, start: ByteIndex) -> io::Result<FileMap> {
+        use std::fs::File;
+        use std::io::Read;
+
+        let name = name.into();
+        let mut file = File::open(&name)?;
+        let mut src = String::new();
+        file.read_to_string(&mut src)?;
+
+        Ok(FileMap::with_index(FileName::Real(name), src, start))
+    }
+
+    /// Construct a new, standalone filemap.
+    ///
+    /// This can be useful for tests that consist of a single source file. Production code should
+    /// however use `CodeMap::add_filemap` or `CodeMap::add_filemap_from_disk` instead.
+    pub fn new<S: AsRef<str>>(name: FileName, src: S) -> FileMap {
+        FileMap::with_index(name, src, ByteIndex(1))
+    }
+
+    pub(super) fn with_index<S>(name: FileName, src: S, start: ByteIndex) -> FileMap
+    where
+        S: AsRef<str>,
+    {
+        use std::iter;
+
+        let src = src.as_ref();
+        let span = ByteSpan::from_offset(start, ByteOffset::from_str(src));
+        let lines = {
+            let newline_off = ByteOffset::from_char_utf8('\n');
+            let offsets = src
+                .match_indices('\n')
+                .map(|(i, _)| ByteOffset(i as RawOffset) + newline_off);
+
+            iter::once(ByteOffset(0)).chain(offsets).collect()
+        };
+
+        FileMap {
+            name,
+            src: src.to_owned(),
+            span,
+            lines,
+        }
+    }
+
+    /// The name of the file that the source came from
+    pub fn name(&self) -> &FileName {
+        &self.name
+    }
+
+    /// The underlying source code
+    pub fn src(&self) -> &str {
+        &self.src.as_ref()
+    }
+
+    /// The span of the source in the `CodeMap`
+    pub fn span(&self) -> ByteSpan {
+        self.span
+    }
+
+    pub fn offset(
+        &self,
+        line: LineIndex,
+        column: ColumnIndex,
+    ) -> Result<ByteOffset, LocationError> {
+        self.byte_index(line, column)
+            .map(|index| index - self.span.start())
+    }
+
+    pub fn byte_index(
+        &self,
+        line: LineIndex,
+        column: ColumnIndex,
+    ) -> Result<ByteIndex, LocationError> {
+        self.line_span(line)
+            .map_err(
+                |LineIndexError::OutOfBounds { given, max }| LocationError::LineOutOfBounds {
+                    given,
+                    max,
+                },
+            )
+            .and_then(|span| {
+                let distance = ColumnIndex(span.end().0 - span.start().0);
+                if column > distance {
+                    Err(LocationError::ColumnOutOfBounds {
+                        given: column,
+                        max: distance,
+                    })
+                } else {
+                    Ok(span.start() + ByteOffset::from(column.0 as i64))
+                }
+            })
+    }
+
+    /// Returns the byte offset to the start of `line`.
+    ///
+    /// Lines may be delimited with either `\n` or `\r\n`.
+    pub fn line_offset(&self, index: LineIndex) -> Result<ByteOffset, LineIndexError> {
+        self.lines
+            .get(index.to_usize())
+            .cloned()
+            .ok_or_else(|| LineIndexError::OutOfBounds {
+                given: index,
+                max: LineIndex(self.lines.len() as RawIndex - 1),
+            })
+    }
+
+    /// Returns the byte index of the start of `line`.
+    ///
+    /// Lines may be delimited with either `\n` or `\r\n`.
+    pub fn line_byte_index(&self, index: LineIndex) -> Result<ByteIndex, LineIndexError> {
+        self.line_offset(index)
+            .map(|offset| self.span.start() + offset)
+    }
+
+    /// Returns the byte offset to the start of `line`.
+    ///
+    /// Lines may be delimited with either `\n` or `\r\n`.
+    pub fn line_span(&self, line: LineIndex) -> Result<ByteSpan, LineIndexError> {
+        let start = self.span.start() + self.line_offset(line)?;
+        let end = match self.line_offset(line + LineOffset(1)) {
+            Ok(offset_hi) => self.span.start() + offset_hi,
+            Err(_) => self.span.end(),
+        };
+
+        Ok(ByteSpan::new(end, start))
+    }
+
+    /// Returns the line and column location of `byte`
+    /// TODO
+    pub fn location(&self, index: ByteIndex) -> Result<(LineIndex, ColumnIndex), ByteIndexError> {
+        let line_index = self.find_line(index)?;
+        let line_span = self.line_span(line_index).unwrap(); // line_index should be valid!
+        let line_slice = self.src_slice(line_span).unwrap(); // line_span should be valid!
+        let byte_col = index - line_span.start();
+        let mut column_i = 0;
+        for c in line_slice[..byte_col.to_usize()].chars() {
+            match c.width() {
+                None => continue,
+                Some(w) => column_i = column_i + w,
+            }
+        }
+        let column_index = ColumnIndex(column_i as RawIndex);
+
+        Ok((line_index, column_index))
+    }
+
+    /// Returns the line index that the byte index points to
+    pub fn find_line(&self, index: ByteIndex) -> Result<LineIndex, ByteIndexError> {
+        if index < self.span.start() || index > self.span.end() {
+            Err(ByteIndexError::OutOfBounds {
+                given: index,
+                span: self.span,
+            })
+        } else {
+            let offset = index - self.span.start();
+
+            if self.src.as_str().is_char_boundary(offset.to_usize()) {
+                match self.lines.binary_search(&offset) {
+                    Ok(i) => Ok(LineIndex(i as RawIndex)),
+                    Err(i) => Ok(LineIndex(i as RawIndex - 1)),
+                }
+            } else {
+                Err(ByteIndexError::InvalidCharBoundary {
+                    given: self.span.start(),
+                })
+            }
+        }
+    }
+
+    /// Get the corresponding source string for a span
+    ///
+    /// Returns `Err` if the span is outside the bounds of the file
+    pub fn src_slice(&self, span: ByteSpan) -> Result<&str, SpanError> {
+        if self.span.contains(span) {
+            let start = (span.start() - self.span.start()).to_usize();
+            let end = (span.end() - self.span.start()).to_usize();
+
+            // TODO: check char boundaries
+            Ok(&self.src.as_str()[start..end])
+        } else {
+            Err(SpanError::OutOfBounds {
+                given: span,
+                span: self.span,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::diagnostics::codemap::CodeMap;
+    use pretty_assertions::assert_eq;
+    use std::sync::Arc;
+
+    use super::*;
+
+    struct TestData {
+        filemap: Arc<FileMap>,
+        lines: &'static [&'static str],
+    }
+
+    impl TestData {
+        fn new() -> TestData {
+            let mut codemap = CodeMap::new();
+            let lines = &[
+                "hello!\n",
+                "howdy\n",
+                "\r\n",
+                "hi萤\n",
+                "bloop\n",
+                "goopey\r\n",
+            ];
+            let filemap = codemap.add_filemap(FileName::Virtual("test".into()), lines.concat());
+
+            TestData { filemap, lines }
+        }
+
+        fn byte_offsets(&self) -> Vec<ByteOffset> {
+            let mut offset = ByteOffset(0);
+            let mut byte_offsets = Vec::new();
+
+            for line in self.lines {
+                byte_offsets.push(offset);
+                offset += ByteOffset::from_str(line);
+
+                let line_end = if line.ends_with("\r\n") {
+                    offset + -ByteOffset::from_char_utf8('\r') + -ByteOffset::from_char_utf8('\n')
+                } else if line.ends_with("\n") {
+                    offset + -ByteOffset::from_char_utf8('\n')
+                } else {
+                    offset
+                };
+
+                byte_offsets.push(line_end);
+            }
+
+            // bump us past the end
+            byte_offsets.push(offset);
+
+            byte_offsets
+        }
+
+        fn byte_indices(&self) -> Vec<ByteIndex> {
+            let mut offsets = vec![ByteIndex::none()];
+            offsets.extend(self.byte_offsets().iter().map(|&off| ByteIndex(1) + off));
+            let out_of_bounds = *offsets.last().unwrap() + ByteOffset(1);
+            offsets.push(out_of_bounds);
+            offsets
+        }
+
+        fn line_indices(&self) -> Vec<LineIndex> {
+            (0..self.lines.len() + 2)
+                .map(|i| LineIndex(i as RawIndex))
+                .collect()
+        }
+    }
+
+    #[test]
+    fn offset() {
+        let test_data = TestData::new();
+        assert!(test_data
+            .filemap
+            .offset(
+                (test_data.lines.len() as u32 - 1).into(),
+                (test_data.lines.last().unwrap().len() as u32).into()
+            )
+            .is_ok());
+        assert!(test_data
+            .filemap
+            .offset(
+                (test_data.lines.len() as u32 - 1).into(),
+                (test_data.lines.last().unwrap().len() as u32 + 1).into()
+            )
+            .is_err());
+    }
+
+    #[test]
+    fn line_offset() {
+        let test_data = TestData::new();
+        let offsets: Vec<_> = test_data
+            .line_indices()
+            .iter()
+            .map(|&i| test_data.filemap.line_offset(i))
+            .collect();
+
+        assert_eq!(
+            offsets,
+            vec![
+                Ok(ByteOffset(0)),
+                Ok(ByteOffset(7)),
+                Ok(ByteOffset(13)),
+                Ok(ByteOffset(15)),
+                Ok(ByteOffset(21)),
+                Ok(ByteOffset(27)),
+                Ok(ByteOffset(35)),
+                Err(LineIndexError::OutOfBounds {
+                    given: LineIndex(7),
+                    max: LineIndex(6),
+                }),
+            ],
+        );
+    }
+
+    #[test]
+    fn line_byte_index() {
+        let test_data = TestData::new();
+        let offsets: Vec<_> = test_data
+            .line_indices()
+            .iter()
+            .map(|&i| test_data.filemap.line_byte_index(i))
+            .collect();
+
+        assert_eq!(
+            offsets,
+            vec![
+                Ok(test_data.filemap.span().start() + ByteOffset(0)),
+                Ok(test_data.filemap.span().start() + ByteOffset(7)),
+                Ok(test_data.filemap.span().start() + ByteOffset(13)),
+                Ok(test_data.filemap.span().start() + ByteOffset(15)),
+                Ok(test_data.filemap.span().start() + ByteOffset(21)),
+                Ok(test_data.filemap.span().start() + ByteOffset(27)),
+                Ok(test_data.filemap.span().start() + ByteOffset(35)),
+                Err(LineIndexError::OutOfBounds {
+                    given: LineIndex(7),
+                    max: LineIndex(6),
+                }),
+            ],
+        );
+    }
+
+    // #[test]
+    // fn line_span() {
+    //     let filemap = filemap();
+    //     let start = filemap.span().start();
+
+    //     assert_eq!(filemap.line_byte_index(Li(0)), Some(start + BOff(0)));
+    //     assert_eq!(filemap.line_byte_index(Li(1)), Some(start + BOff(7)));
+    //     assert_eq!(filemap.line_byte_index(Li(2)), Some(start + BOff(13)));
+    //     assert_eq!(filemap.line_byte_index(Li(3)), Some(start + BOff(14)));
+    //     assert_eq!(filemap.line_byte_index(Li(4)), Some(start + BOff(20)));
+    //     assert_eq!(filemap.line_byte_index(Li(5)), Some(start + BOff(26)));
+    //     assert_eq!(filemap.line_byte_index(Li(6)), None);
+    // }
+
+    #[test]
+    fn location() {
+        let test_data = TestData::new();
+        let lines: Vec<_> = test_data
+            .byte_indices()
+            .iter()
+            .map(|&index| test_data.filemap.location(index))
+            .collect();
+
+        assert_eq!(
+            lines,
+            vec![
+                Err(ByteIndexError::OutOfBounds {
+                    given: ByteIndex(0),
+                    span: test_data.filemap.span(),
+                }),
+                Ok((LineIndex(0), ColumnIndex(0))),
+                Ok((LineIndex(0), ColumnIndex(6))),
+                Ok((LineIndex(1), ColumnIndex(0))),
+                Ok((LineIndex(1), ColumnIndex(5))),
+                Ok((LineIndex(2), ColumnIndex(0))),
+                Ok((LineIndex(2), ColumnIndex(0))),
+                Ok((LineIndex(3), ColumnIndex(0))),
+                Ok((LineIndex(3), ColumnIndex(4))),
+                Ok((LineIndex(4), ColumnIndex(0))),
+                Ok((LineIndex(4), ColumnIndex(5))),
+                Ok((LineIndex(5), ColumnIndex(0))),
+                Ok((LineIndex(5), ColumnIndex(6))),
+                Ok((LineIndex(6), ColumnIndex(0))),
+                Err(ByteIndexError::OutOfBounds {
+                    given: ByteIndex(37),
+                    span: test_data.filemap.span()
+                }),
+            ],
+        );
+    }
+
+    #[test]
+    fn find_line() {
+        let test_data = TestData::new();
+        let lines: Vec<_> = test_data
+            .byte_indices()
+            .iter()
+            .map(|&index| test_data.filemap.find_line(index))
+            .collect();
+
+        assert_eq!(
+            lines,
+            vec![
+                Err(ByteIndexError::OutOfBounds {
+                    given: ByteIndex(0),
+                    span: test_data.filemap.span(),
+                }),
+                Ok(LineIndex(0)),
+                Ok(LineIndex(0)),
+                Ok(LineIndex(1)),
+                Ok(LineIndex(1)),
+                Ok(LineIndex(2)),
+                Ok(LineIndex(2)),
+                Ok(LineIndex(3)),
+                Ok(LineIndex(3)),
+                Ok(LineIndex(4)),
+                Ok(LineIndex(4)),
+                Ok(LineIndex(5)),
+                Ok(LineIndex(5)),
+                Ok(LineIndex(6)),
+                Err(ByteIndexError::OutOfBounds {
+                    given: ByteIndex(37),
+                    span: test_data.filemap.span(),
+                }),
+            ],
+        );
+    }
+}

--- a/diagnostics/src/diagnostics/index.rs
+++ b/diagnostics/src/diagnostics/index.rs
@@ -1,0 +1,338 @@
+//! Wrapper types that specify positions in a source file
+
+use std::fmt;
+use std::ops::{Add, AddAssign, Neg, Sub, SubAssign};
+
+/// The raw, untyped index
+pub type RawIndex = u32;
+
+/// The raw, untyped offset
+pub type RawOffset = i64;
+
+/// A zero-indexed line offset into a source file
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct LineIndex(pub RawIndex);
+impl LineIndex {
+    /// The 1-indexed line number. Useful for pretty printing source locations.
+    pub fn number(self) -> LineNumber {
+        LineNumber(self.0 + 1)
+    }
+
+    /// Convert the index into a `usize`, for use in array indexing
+    pub fn to_usize(self) -> usize {
+        self.0 as usize
+    }
+}
+impl Default for LineIndex {
+    fn default() -> LineIndex {
+        LineIndex(0)
+    }
+}
+impl fmt::Debug for LineIndex {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "LineIndex({})", self.0)
+    }
+}
+
+/// A 1-indexed line number. Useful for pretty printing source locations.
+pub struct LineNumber(RawIndex);
+impl fmt::Debug for LineNumber {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "LineNumber({})", self.0)
+    }
+}
+impl fmt::Display for LineNumber {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A line offset in a source file
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct LineOffset(pub RawOffset);
+impl Default for LineOffset {
+    fn default() -> LineOffset {
+        LineOffset(0)
+    }
+}
+impl fmt::Debug for LineOffset {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+impl fmt::Display for LineOffset {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A zero-indexed column offset into a source file
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ColumnIndex(pub RawIndex);
+impl ColumnIndex {
+    /// The 1-indexed column number. Useful for pretty printing source locations.
+    #[inline]
+    pub fn number(self) -> ColumnNumber {
+        ColumnNumber(self.0 + 1)
+    }
+
+    /// Convert the index into a `usize`, for use in array indexing
+    #[inline]
+    pub fn to_usize(self) -> usize {
+        self.0 as usize
+    }
+}
+impl Default for ColumnIndex {
+    fn default() -> ColumnIndex {
+        ColumnIndex(0)
+    }
+}
+impl fmt::Debug for ColumnIndex {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ColumnIndex({})", self.0)
+    }
+}
+
+/// A 1-indexed column number. Useful for pretty printing source locations.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ColumnNumber(RawIndex);
+impl fmt::Debug for ColumnNumber {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ColumnNumber({})", self.0)
+    }
+}
+impl fmt::Display for ColumnNumber {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A column offset in a source file
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ColumnOffset(pub RawOffset);
+impl Default for ColumnOffset {
+    fn default() -> ColumnOffset {
+        ColumnOffset(0)
+    }
+}
+impl fmt::Debug for ColumnOffset {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ColumnOffset({})", self.0)
+    }
+}
+impl fmt::Display for ColumnOffset {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A byte position in a source file
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ByteIndex(pub RawIndex);
+impl ByteIndex {
+    /// A byte position that will never point to a valid file
+    pub fn none() -> ByteIndex {
+        ByteIndex(0)
+    }
+
+    /// Convert the position into a `usize`, for use in array indexing
+    #[inline]
+    pub fn to_usize(self) -> usize {
+        self.0 as usize
+    }
+}
+impl Default for ByteIndex {
+    fn default() -> ByteIndex {
+        ByteIndex(0)
+    }
+}
+impl fmt::Debug for ByteIndex {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ByteIndex({})", self.0)
+    }
+}
+impl fmt::Display for ByteIndex {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", 0)
+    }
+}
+
+/// A byte offset in a source file
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ByteOffset(pub RawOffset);
+
+impl ByteOffset {
+    /// Create a byte offset from a UTF8-encoded character
+    #[inline]
+    pub fn from_char_utf8(ch: char) -> ByteOffset {
+        ByteOffset(ch.len_utf8() as RawOffset)
+    }
+
+    /// Create a byte offset from a UTF- encoded string
+    #[inline]
+    pub fn from_str(value: &str) -> ByteOffset {
+        ByteOffset(value.len() as RawOffset)
+    }
+
+    /// Convert the offset into a `usize`, for use in array indexing
+    #[inline]
+    pub fn to_usize(self) -> usize {
+        self.0 as usize
+    }
+}
+impl Default for ByteOffset {
+    #[inline]
+    fn default() -> ByteOffset {
+        ByteOffset(0)
+    }
+}
+impl fmt::Debug for ByteOffset {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ByteOffset({})", self.0)
+    }
+}
+impl fmt::Display for ByteOffset {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A relative offset between two indices
+///
+/// These can be thought of as 1-dimensional vectors
+pub trait Offset: Copy + Ord
+where
+    Self: Neg<Output = Self>,
+    Self: Add<Self, Output = Self>,
+    Self: AddAssign<Self>,
+    Self: Sub<Self, Output = Self>,
+    Self: SubAssign<Self>,
+{
+    const ZERO: Self;
+}
+
+/// Index types
+///
+/// These can be thought of as 1-dimensional points
+pub trait Index: Copy + Ord
+where
+    Self: Add<<Self as Index>::Offset, Output = Self>,
+    Self: AddAssign<<Self as Index>::Offset>,
+    Self: Sub<<Self as Index>::Offset, Output = Self>,
+    Self: SubAssign<<Self as Index>::Offset>,
+    Self: Sub<Self, Output = <Self as Index>::Offset>,
+{
+    type Offset: Offset;
+}
+
+macro_rules! impl_index {
+    ($Index:ident, $Offset:ident) => {
+        impl From<RawOffset> for $Offset {
+            #[inline]
+            fn from(i: RawOffset) -> Self {
+                $Offset(i)
+            }
+        }
+
+        impl From<RawIndex> for $Index {
+            #[inline]
+            fn from(i: RawIndex) -> Self {
+                $Index(i)
+            }
+        }
+
+        impl Offset for $Offset {
+            const ZERO: $Offset = $Offset(0);
+        }
+
+        impl Index for $Index {
+            type Offset = $Offset;
+        }
+
+        impl Add<$Offset> for $Index {
+            type Output = $Index;
+
+            #[inline]
+            fn add(self, rhs: $Offset) -> $Index {
+                $Index((self.0 as RawOffset + rhs.0) as RawIndex)
+            }
+        }
+
+        impl AddAssign<$Offset> for $Index {
+            #[inline]
+            fn add_assign(&mut self, rhs: $Offset) {
+                *self = *self + rhs;
+            }
+        }
+
+        impl Neg for $Offset {
+            type Output = $Offset;
+
+            #[inline]
+            fn neg(self) -> $Offset {
+                $Offset(-self.0)
+            }
+        }
+
+        impl Add<$Offset> for $Offset {
+            type Output = $Offset;
+
+            #[inline]
+            fn add(self, rhs: $Offset) -> $Offset {
+                $Offset(self.0 + rhs.0)
+            }
+        }
+
+        impl AddAssign<$Offset> for $Offset {
+            #[inline]
+            fn add_assign(&mut self, rhs: $Offset) {
+                self.0 += rhs.0;
+            }
+        }
+
+        impl Sub<$Offset> for $Offset {
+            type Output = $Offset;
+
+            #[inline]
+            fn sub(self, rhs: $Offset) -> $Offset {
+                $Offset(self.0 - rhs.0)
+            }
+        }
+
+        impl SubAssign<$Offset> for $Offset {
+            #[inline]
+            fn sub_assign(&mut self, rhs: $Offset) {
+                self.0 -= rhs.0;
+            }
+        }
+
+        impl Sub for $Index {
+            type Output = $Offset;
+
+            #[inline]
+            fn sub(self, rhs: $Index) -> $Offset {
+                $Offset(self.0 as RawOffset - rhs.0 as RawOffset)
+            }
+        }
+
+        impl Sub<$Offset> for $Index {
+            type Output = $Index;
+
+            #[inline]
+            fn sub(self, rhs: $Offset) -> $Index {
+                $Index((self.0 as RawOffset - rhs.0 as RawOffset) as u32)
+            }
+        }
+
+        impl SubAssign<$Offset> for $Index {
+            #[inline]
+            fn sub_assign(&mut self, rhs: $Offset) {
+                self.0 = (self.0 as RawOffset - rhs.0) as RawIndex;
+            }
+        }
+    };
+}
+
+impl_index!(LineIndex, LineOffset);
+impl_index!(ColumnIndex, ColumnOffset);
+impl_index!(ByteIndex, ByteOffset);

--- a/diagnostics/src/diagnostics/span.rs
+++ b/diagnostics/src/diagnostics/span.rs
@@ -1,0 +1,288 @@
+use std::cmp::Ordering;
+use std::{cmp, fmt};
+
+use super::index::{ByteIndex, Index};
+
+/// A region of code in a source file
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub struct Span<I> {
+    start: I,
+    end: I,
+}
+impl<I: Ord> Span<I> {
+    /// Create a new span
+    ///
+    /// ```rust
+    /// use liblumen_diagnostics::{ByteIndex, Span};
+    ///
+    /// let span = Span::new(ByteIndex(3), ByteIndex(6));
+    /// assert_eq!(span.start(), ByteIndex(3));
+    /// assert_eq!(span.end(), ByteIndex(6));
+    /// ```
+    ///
+    /// `start` and `end` are reordered to maintain the invariant that `start <= end`
+    ///
+    /// ```rust
+    /// use liblumen_diagnostics::{ByteIndex, Span};
+    ///
+    /// let span = Span::new(ByteIndex(6), ByteIndex(3));
+    /// assert_eq!(span.start(), ByteIndex(3));
+    /// assert_eq!(span.end(), ByteIndex(6));
+    /// ```
+    #[inline]
+    pub fn new(start: I, end: I) -> Span<I> {
+        if start <= end {
+            Span { start, end }
+        } else {
+            Span {
+                start: end,
+                end: start,
+            }
+        }
+    }
+
+    #[inline]
+    pub fn map<F, J>(self, mut f: F) -> Span<J>
+    where
+        F: FnMut(I) -> J,
+        J: Ord,
+    {
+        Span::new(f(self.start), f(self.end))
+    }
+}
+impl<I> Span<I> {
+    /// Get the start index
+    #[inline]
+    pub fn start(self) -> I {
+        self.start
+    }
+
+    /// Get the end index
+    #[inline]
+    pub fn end(self) -> I {
+        self.end
+    }
+}
+impl<I: Index> Span<I> {
+    /// Makes a span from offsets relative to the start of this span.
+    #[inline]
+    pub fn subspan(&self, begin: I::Offset, end: I::Offset) -> Span<I> {
+        debug_assert!(end >= begin);
+        debug_assert!(self.start() + end <= self.end());
+        Span {
+            start: self.start() + begin,
+            end: self.start() + end,
+        }
+    }
+
+    /// Create a new span from this one by shrinking the front of the span, i.e. increasing it by
+    /// some offset
+    #[inline]
+    pub fn shrink_front(self, shift: I::Offset) -> Span<I> {
+        Span::new(self.start() + shift, self.end())
+    }
+
+    /// Create a new span from a byte start and an offset
+    #[inline]
+    pub fn from_offset(start: I, off: I::Offset) -> Span<I> {
+        Span::new(start, start + off)
+    }
+
+    /// Return a new span with the low byte position replaced with the supplied byte position
+    ///
+    /// ```rust
+    /// use liblumen_diagnostics::{ByteIndex, Span};
+    ///
+    /// let span = Span::new(ByteIndex(3), ByteIndex(6));
+    /// assert_eq!(
+    ///     span.with_start(ByteIndex(2)),
+    ///     Span::new(ByteIndex(2), ByteIndex(6))
+    /// );
+    /// assert_eq!(
+    ///     span.with_start(ByteIndex(5)),
+    ///     Span::new(ByteIndex(5), ByteIndex(6))
+    /// );
+    /// assert_eq!(
+    ///     span.with_start(ByteIndex(7)),
+    ///     Span::new(ByteIndex(6), ByteIndex(7))
+    /// );
+    /// ```
+    #[inline]
+    pub fn with_start(self, start: I) -> Span<I> {
+        Span::new(start, self.end())
+    }
+
+    /// Return a new span with the high byte position replaced with the supplied byte position
+    ///
+    /// ```rust
+    /// use liblumen_diagnostics::{ByteIndex, Span};
+    ///
+    /// let span = Span::new(ByteIndex(3), ByteIndex(6));
+    /// assert_eq!(
+    ///     span.with_end(ByteIndex(7)),
+    ///     Span::new(ByteIndex(3), ByteIndex(7))
+    /// );
+    /// assert_eq!(
+    ///     span.with_end(ByteIndex(5)),
+    ///     Span::new(ByteIndex(3), ByteIndex(5))
+    /// );
+    /// assert_eq!(
+    ///     span.with_end(ByteIndex(2)),
+    ///     Span::new(ByteIndex(2), ByteIndex(3))
+    /// );
+    /// ```
+    #[inline]
+    pub fn with_end(self, end: I) -> Span<I> {
+        Span::new(self.start(), end)
+    }
+
+    /// Return true if `self` fully encloses `other`.
+    ///
+    /// ```rust
+    /// use liblumen_diagnostics::{ByteIndex, Span};
+    ///
+    /// let a = Span::new(ByteIndex(5), ByteIndex(8));
+    ///
+    /// assert_eq!(a.contains(a), true);
+    /// assert_eq!(a.contains(Span::new(ByteIndex(6), ByteIndex(7))), true);
+    /// assert_eq!(a.contains(Span::new(ByteIndex(6), ByteIndex(10))), false);
+    /// assert_eq!(a.contains(Span::new(ByteIndex(3), ByteIndex(6))), false);
+    /// ```
+    #[inline]
+    pub fn contains(self, other: Span<I>) -> bool {
+        self.start() <= other.start() && other.end() <= self.end()
+    }
+
+    /// Return `Equal` if `self` contains `pos`, otherwise it returns `Less` if `pos` is before
+    /// `start` or `Greater` if `pos` is after or at `end`.
+    ///
+    /// ```rust
+    /// use liblumen_diagnostics::{ByteIndex, Span};
+    /// use std::cmp::Ordering::*;
+    ///
+    /// let a = Span::new(ByteIndex(5), ByteIndex(8));
+    ///
+    /// assert_eq!(a.containment(ByteIndex(4)), Less);
+    /// assert_eq!(a.containment(ByteIndex(5)), Equal);
+    /// assert_eq!(a.containment(ByteIndex(6)), Equal);
+    /// assert_eq!(a.containment(ByteIndex(8)), Equal);
+    /// assert_eq!(a.containment(ByteIndex(9)), Greater);
+    /// ```
+    #[inline]
+    pub fn containment(self, pos: I) -> Ordering {
+        use std::cmp::Ordering::*;
+
+        match (pos.cmp(&self.start), pos.cmp(&self.end)) {
+            (Equal, _) | (_, Equal) | (Greater, Less) => Equal,
+            (Less, _) => Less,
+            (_, Greater) => Greater,
+        }
+    }
+
+    /// Return `Equal` if `self` contains `pos`, otherwise it returns `Less` if `pos` is before
+    /// `start` or `Greater` if `pos` is *strictly* after `end`.
+    ///
+    /// ```rust
+    /// use liblumen_diagnostics::{ByteIndex, Span};
+    /// use std::cmp::Ordering::*;
+    ///
+    /// let a = Span::new(ByteIndex(5), ByteIndex(8));
+    ///
+    /// assert_eq!(a.containment_exclusive(ByteIndex(4)), Less);
+    /// assert_eq!(a.containment_exclusive(ByteIndex(5)), Equal);
+    /// assert_eq!(a.containment_exclusive(ByteIndex(6)), Equal);
+    /// assert_eq!(a.containment_exclusive(ByteIndex(8)), Greater);
+    /// assert_eq!(a.containment_exclusive(ByteIndex(9)), Greater);
+    /// ```
+    #[inline]
+    pub fn containment_exclusive(self, pos: I) -> Ordering {
+        if self.end == pos {
+            Ordering::Greater
+        } else {
+            self.containment(pos)
+        }
+    }
+
+    /// Return a `Span` that would enclose both `self` and `end`.
+    ///
+    /// ```plain
+    /// self     ~~~~~~~
+    /// end                     ~~~~~~~~
+    /// returns  ~~~~~~~~~~~~~~~~~~~~~~~
+    /// ```
+    ///
+    /// ```rust
+    /// use liblumen_diagnostics::{ByteIndex, Span};
+    ///
+    /// let a = Span::new(ByteIndex(2), ByteIndex(5));
+    /// let b = Span::new(ByteIndex(10), ByteIndex(14));
+    ///
+    /// assert_eq!(a.to(b), Span::new(ByteIndex(2), ByteIndex(14)));
+    /// ```
+    #[inline]
+    pub fn to(self, end: Span<I>) -> Span<I> {
+        Span::new(
+            cmp::min(self.start(), end.start()),
+            cmp::max(self.end(), end.end()),
+        )
+    }
+
+    /// Return a `Span` between the end of `self` to the beginning of `end`.
+    ///
+    /// ```plain
+    /// self     ~~~~~~~
+    /// end                     ~~~~~~~~
+    /// returns         ~~~~~~~~~
+    /// ```
+    ///
+    /// ```rust
+    /// use liblumen_diagnostics::{ByteIndex, Span};
+    ///
+    /// let a = Span::new(ByteIndex(2), ByteIndex(5));
+    /// let b = Span::new(ByteIndex(10), ByteIndex(14));
+    ///
+    /// assert_eq!(a.between(b), Span::new(ByteIndex(5), ByteIndex(10)));
+    /// ```
+    #[inline]
+    pub fn between(self, end: Span<I>) -> Span<I> {
+        Span::new(self.end(), end.start())
+    }
+
+    /// Return a `Span` between the beginning of `self` to the beginning of `end`.
+    ///
+    /// ```plain
+    /// self     ~~~~~~~
+    /// end                     ~~~~~~~~
+    /// returns  ~~~~~~~~~~~~~~~~
+    /// ```
+    ///
+    /// ```rust
+    /// use liblumen_diagnostics::{ByteIndex, Span};
+    ///
+    /// let a = Span::new(ByteIndex(2), ByteIndex(5));
+    /// let b = Span::new(ByteIndex(10), ByteIndex(14));
+    ///
+    /// assert_eq!(a.until(b), Span::new(ByteIndex(2), ByteIndex(10)));
+    /// ```
+    #[inline]
+    pub fn until(self, end: Span<I>) -> Span<I> {
+        Span::new(self.start(), end.start())
+    }
+}
+
+impl<I: fmt::Display> fmt::Display for Span<I> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.start.fmt(f)?;
+        write!(f, "..")?;
+        self.end.fmt(f)?;
+        Ok(())
+    }
+}
+
+/// A span of byte indices
+pub type ByteSpan = Span<ByteIndex>;
+
+pub const DUMMY_SPAN: Span<ByteIndex> = Span {
+    start: ByteIndex(0),
+    end: ByteIndex(0),
+};

--- a/diagnostics/src/lib.rs
+++ b/diagnostics/src/lib.rs
@@ -1,0 +1,5 @@
+mod diagnostics;
+mod reporting;
+
+pub use self::diagnostics::*;
+pub use self::reporting::*;

--- a/diagnostics/src/reporting.rs
+++ b/diagnostics/src/reporting.rs
@@ -1,0 +1,117 @@
+use std::cmp::Ordering;
+use std::fmt;
+use std::str::FromStr;
+
+pub use termcolor::{Color, ColorChoice, ColorSpec};
+
+mod diagnostic;
+pub mod emitter;
+
+pub use self::diagnostic::{Diagnostic, Label, LabelStyle};
+pub use self::emitter::{Emitter, NullEmitter, StandardStreamEmitter};
+
+/// A severity level for diagnostic messages
+///
+/// These are ordered in the following way:
+///
+/// * Bug
+/// * Error
+/// * Warning
+/// * Note
+/// * Help
+#[derive(Copy, Clone, PartialEq, Hash, Debug)]
+pub enum Severity {
+    /// An unexpected bug.
+    Bug,
+    /// An error.
+    Error,
+    /// A warning.
+    Warning,
+    /// A note.
+    Note,
+    /// A help message.
+    Help,
+}
+impl Severity {
+    /// We want bugs to be the maximum severity, errors next, etc...
+    fn to_cmp_int(self) -> u8 {
+        match self {
+            Severity::Bug => 5,
+            Severity::Error => 4,
+            Severity::Warning => 3,
+            Severity::Note => 2,
+            Severity::Help => 1,
+        }
+    }
+}
+impl PartialOrd for Severity {
+    fn partial_cmp(&self, other: &Severity) -> Option<Ordering> {
+        u8::partial_cmp(&self.to_cmp_int(), &other.to_cmp_int())
+    }
+}
+impl fmt::Display for Severity {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.to_str().fmt(f)
+    }
+}
+impl Severity {
+    /// Return the termcolor to use when rendering messages of this diagnostic severity
+    pub fn color(self) -> Color {
+        match self {
+            Severity::Bug | Severity::Error => Color::Red,
+            Severity::Warning => Color::Yellow,
+            Severity::Note => Color::Green,
+            Severity::Help => Color::Cyan,
+        }
+    }
+
+    /// A string that explains this diagnostic severity
+    pub fn to_str(self) -> &'static str {
+        match self {
+            Severity::Bug => "error: internal compiler error",
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+            Severity::Note => "note",
+            Severity::Help => "help",
+        }
+    }
+}
+
+/// A command line argument that configures the coloring of the output
+///
+/// This can be used with command line argument parsers like `clap` or `structopt`.
+///
+/// # Example
+///
+/// ```rust
+/// use liblumen_diagnostics::UseColors;
+/// use std::str::FromStr;
+///
+/// fn main() {
+///     let _color = UseColors::from_str("always");
+/// }
+/// ```
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct UseColors(pub ColorChoice);
+impl UseColors {
+    /// Allowed string variants to be used on the command line
+    pub const VARIANTS: &'static [&'static str] = &["auto", "always", "ansi", "never"];
+}
+impl FromStr for UseColors {
+    type Err = &'static str;
+
+    fn from_str(src: &str) -> Result<UseColors, &'static str> {
+        match src {
+            _ if src.eq_ignore_ascii_case("auto") => Ok(UseColors(ColorChoice::Auto)),
+            _ if src.eq_ignore_ascii_case("always") => Ok(UseColors(ColorChoice::Always)),
+            _ if src.eq_ignore_ascii_case("ansi") => Ok(UseColors(ColorChoice::AlwaysAnsi)),
+            _ if src.eq_ignore_ascii_case("never") => Ok(UseColors(ColorChoice::Never)),
+            _ => Err("valid values: auto, always, ansi, never"),
+        }
+    }
+}
+impl Into<ColorChoice> for UseColors {
+    fn into(self) -> ColorChoice {
+        self.0
+    }
+}

--- a/diagnostics/src/reporting/diagnostic.rs
+++ b/diagnostics/src/reporting/diagnostic.rs
@@ -1,0 +1,112 @@
+//! Diagnostic reporting support for the codespan crate
+use std::fmt;
+
+use crate::diagnostics::ByteSpan;
+
+use super::Severity;
+
+/// A style for the label
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum LabelStyle {
+    /// The main focus of the diagnostic
+    Primary,
+    /// Supporting labels that may help to isolate the cause of the diagnostic
+    Secondary,
+}
+
+/// A label describing an underlined region of code associated with a diagnostic
+#[derive(Clone, Debug)]
+pub struct Label {
+    /// The span we are going to include in the final snippet.
+    pub span: ByteSpan,
+    /// A message to provide some additional information for the underlined code.
+    pub message: Option<String>,
+    /// The style to use for the label.
+    pub style: LabelStyle,
+}
+impl Label {
+    pub fn new(span: ByteSpan, style: LabelStyle) -> Label {
+        Label {
+            span,
+            message: None,
+            style,
+        }
+    }
+
+    pub fn new_primary(span: ByteSpan) -> Label {
+        Label::new(span, LabelStyle::Primary)
+    }
+
+    pub fn new_secondary(span: ByteSpan) -> Label {
+        Label::new(span, LabelStyle::Secondary)
+    }
+
+    pub fn with_message<S: Into<String>>(mut self, message: S) -> Label {
+        self.message = Some(message.into());
+        self
+    }
+}
+
+/// Represents a diagnostic message and associated child messages.
+#[derive(Clone, Debug)]
+pub struct Diagnostic {
+    /// The overall severity of the diagnostic
+    pub severity: Severity,
+    /// An optional code that identifies this diagnostic.
+    pub code: Option<String>,
+    /// The main message associated with this diagnostic
+    pub message: String,
+    /// The labelled spans marking the regions of code that cause this
+    /// diagnostic to be raised
+    pub labels: Vec<Label>,
+}
+impl Diagnostic {
+    pub fn new<S: Into<String>>(severity: Severity, message: S) -> Diagnostic {
+        Diagnostic {
+            severity,
+            code: None,
+            message: message.into(),
+            labels: Vec::new(),
+        }
+    }
+
+    pub fn new_bug<S: Into<String>>(message: S) -> Diagnostic {
+        Diagnostic::new(Severity::Bug, message)
+    }
+
+    pub fn new_error<S: Into<String>>(message: S) -> Diagnostic {
+        Diagnostic::new(Severity::Error, message)
+    }
+
+    pub fn new_warning<S: Into<String>>(message: S) -> Diagnostic {
+        Diagnostic::new(Severity::Warning, message)
+    }
+
+    pub fn new_note<S: Into<String>>(message: S) -> Diagnostic {
+        Diagnostic::new(Severity::Note, message)
+    }
+
+    pub fn new_help<S: Into<String>>(message: S) -> Diagnostic {
+        Diagnostic::new(Severity::Help, message)
+    }
+
+    pub fn with_code<S: Into<String>>(mut self, code: S) -> Diagnostic {
+        self.code = Some(code.into());
+        self
+    }
+
+    pub fn with_label(mut self, label: Label) -> Diagnostic {
+        self.labels.push(label);
+        self
+    }
+
+    pub fn with_labels<Labels: IntoIterator<Item = Label>>(mut self, labels: Labels) -> Diagnostic {
+        self.labels.extend(labels);
+        self
+    }
+}
+impl fmt::Display for Diagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}

--- a/diagnostics/src/reporting/emitter.rs
+++ b/diagnostics/src/reporting/emitter.rs
@@ -1,0 +1,371 @@
+use std::fmt::{self, Display};
+use std::io;
+use std::sync::{Arc, Mutex};
+
+use failure::Error;
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+use unicode_width::UnicodeWidthStr;
+
+use crate::diagnostics::CodeMap;
+
+use super::{Diagnostic, LabelStyle, Severity};
+
+struct Pad<T>(T, usize);
+impl<T: fmt::Display> fmt::Display for Pad<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for _ in 0..(self.1) {
+            self.0.fmt(f)?;
+        }
+        Ok(())
+    }
+}
+
+pub trait Emitter {
+    fn emit(&self, color: Option<ColorSpec>, message: &str) -> io::Result<()>;
+    fn debug(&self, color: Option<ColorSpec>, message: &str) -> io::Result<()>;
+    fn warn(&self, color: Option<ColorSpec>, message: &str) -> io::Result<()>;
+    fn error(&self, err: Error) -> io::Result<()>;
+    fn diagnostic(&self, diagnostic: &Diagnostic) -> io::Result<()>;
+}
+
+/// This emitter swallows all output
+pub struct NullEmitter(Severity);
+impl NullEmitter {
+    pub fn new() -> Self {
+        NullEmitter(Severity::Help)
+    }
+}
+impl Emitter for NullEmitter {
+    fn emit(&self, _color: Option<ColorSpec>, _message: &str) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn debug(&self, _color: Option<ColorSpec>, _message: &str) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn warn(&self, _color: Option<ColorSpec>, _message: &str) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn error(&self, _err: Error) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn diagnostic(&self, _diagnostic: &Diagnostic) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// This emitter writes output to either stdout/stderr
+pub struct StandardStreamEmitter {
+    severity: Severity,
+    stdout: StandardStream,
+    stderr: StandardStream,
+    codemap: Option<Arc<Mutex<CodeMap>>>,
+}
+impl StandardStreamEmitter {
+    pub fn new(color: ColorChoice) -> Self {
+        StandardStreamEmitter {
+            severity: Severity::Help,
+            stdout: StandardStream::stdout(color),
+            stderr: StandardStream::stderr(color),
+            codemap: None,
+        }
+    }
+
+    pub fn set_min_severity(mut self, severity: Severity) -> Self {
+        self.severity = severity;
+        self
+    }
+
+    pub fn set_codemap(mut self, codemap: Arc<Mutex<CodeMap>>) -> Self {
+        self.codemap = Some(codemap);
+        self
+    }
+}
+impl Emitter for StandardStreamEmitter {
+    fn emit(&self, color: Option<ColorSpec>, message: &str) -> io::Result<()> {
+        let mut handle = self.stdout.lock();
+        write_color(&mut handle, color, message)
+    }
+
+    fn debug(&self, color: Option<ColorSpec>, message: &str) -> io::Result<()> {
+        let mut handle = self.stderr.lock();
+        write_color(&mut handle, color, message)
+    }
+
+    fn warn(&self, color: Option<ColorSpec>, message: &str) -> io::Result<()> {
+        let mut handle = self.stderr.lock();
+        write_color(&mut handle, color, message)
+    }
+
+    fn error(&self, err: Error) -> io::Result<()> {
+        let mut handle = self.stderr.lock();
+        write_error(&mut handle, err)
+    }
+
+    fn diagnostic(&self, diagnostic: &Diagnostic) -> io::Result<()> {
+        if diagnostic.severity >= self.severity {
+            let mut handle = self.stdout.lock();
+
+            match self.codemap {
+                None => write_unlabeled_diagnostic(&mut handle, diagnostic)?,
+                Some(ref codemap) => write_labeled_diagnostic(&mut handle, codemap, diagnostic)?,
+            };
+        }
+        Ok(())
+    }
+}
+
+fn write_color<W, M>(mut writer: W, color: Option<ColorSpec>, message: M) -> io::Result<()>
+where
+    W: WriteColor,
+    M: Display,
+{
+    if let Some(ref color) = color {
+        writer.set_color(&color)?;
+    }
+    write!(writer, "{}", message)?;
+
+    writer.reset()?;
+
+    Ok(())
+}
+
+fn write_error<W>(mut writer: W, err: Error) -> io::Result<()>
+where
+    W: WriteColor,
+{
+    let severity = Severity::Error;
+    let failure = err.as_fail();
+
+    let highlight_color = ColorSpec::new().set_bold(true).set_intense(true).clone();
+
+    writer.set_color(&highlight_color.clone().set_fg(Some(severity.color())))?;
+    write!(writer, "{}", severity)?;
+
+    writer.set_color(&highlight_color)?;
+    writeln!(writer, ": {}", failure)?;
+    writer.reset()?;
+
+    // Print root cause
+    let cause = failure.find_root_cause();
+    // It is possible that the failure has no root, which returns self,
+    // so don't print errors twice in that case
+    if std::ptr::eq(cause, failure) {
+        write!(writer, "\n")?;
+        writer.set_color(&highlight_color.clone().set_fg(Some(severity.color())))?;
+        write!(writer, "CAUSE")?;
+
+        writer.set_color(&highlight_color)?;
+        writeln!(writer, ": {}", cause)?;
+    }
+
+    // Show backtrace only in debug mode
+    if cfg!(debug_assertions) {
+        if let Some(ref trace) = failure.backtrace() {
+            write!(writer, "\n\n{:?}", trace)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn write_unlabeled_diagnostic<W>(mut writer: W, diagnostic: &Diagnostic) -> io::Result<()>
+where
+    W: WriteColor,
+{
+    let highlight_color = ColorSpec::new().set_bold(true).set_intense(true).clone();
+
+    writer.set_color(
+        &highlight_color
+            .clone()
+            .set_fg(Some(diagnostic.severity.color())),
+    )?;
+    write!(writer, "{}", diagnostic.severity)?;
+
+    if let Some(ref code) = diagnostic.code {
+        write!(writer, "[{}]", code)?;
+    }
+
+    writer.set_color(&highlight_color)?;
+    writeln!(writer, ": {}", diagnostic.message)?;
+    writer.reset()?;
+
+    Ok(())
+}
+
+fn write_labeled_diagnostic<W>(
+    mut writer: W,
+    codemap: &Arc<Mutex<CodeMap>>,
+    diagnostic: &Diagnostic,
+) -> io::Result<()>
+where
+    W: WriteColor,
+{
+    let supports_color = writer.supports_color();
+    let line_location_color = ColorSpec::new()
+        // Blue is really difficult to see on the standard windows command line
+        .set_fg(Some(if cfg!(windows) {
+            Color::Cyan
+        } else {
+            Color::Blue
+        }))
+        .clone();
+    let diagnostic_color = ColorSpec::new()
+        .set_fg(Some(diagnostic.severity.color()))
+        .clone();
+
+    let highlight_color = ColorSpec::new().set_bold(true).set_intense(true).clone();
+
+    writer.set_color(
+        &highlight_color
+            .clone()
+            .set_fg(Some(diagnostic.severity.color())),
+    )?;
+    write!(writer, "{}", diagnostic.severity)?;
+
+    if let Some(ref code) = diagnostic.code {
+        write!(writer, "[{}]", code)?;
+    }
+
+    writer.set_color(&highlight_color)?;
+    writeln!(writer, ": {}", diagnostic.message)?;
+    writer.reset()?;
+
+    for label in &diagnostic.labels {
+        match codemap.lock().unwrap().find_file(label.span.start()) {
+            None => {
+                if let Some(ref message) = label.message {
+                    writeln!(writer, "- {}", message)?
+                }
+            }
+            Some(file) => {
+                let (line, column) = file.location(label.span.start()).expect("location");
+                writeln!(
+                    writer,
+                    "- {file}:{line}:{column}",
+                    file = file.name(),
+                    line = line.number(),
+                    column = column.number(),
+                )?;
+
+                let line_span = file.line_span(line).expect("line_span");
+
+                let line_prefix = file
+                    .src_slice(line_span.with_end(label.span.start()))
+                    .expect("line_prefix");
+                let line_marked = file.src_slice(label.span).expect("line_marked");
+                let line_suffix = file
+                    .src_slice(line_span.with_start(label.span.end()))
+                    .expect("line_suffix")
+                    .trim_end_matches(|ch: char| ch == '\r' || ch == '\n');
+
+                let mark = match label.style {
+                    LabelStyle::Primary => '^',
+                    LabelStyle::Secondary => '-',
+                };
+                let label_color = match label.style {
+                    LabelStyle::Primary => diagnostic_color.clone(),
+                    LabelStyle::Secondary => ColorSpec::new()
+                        .set_fg(Some(if cfg!(windows) {
+                            Color::Cyan
+                        } else {
+                            Color::Blue
+                        }))
+                        .clone(),
+                };
+
+                writer.set_color(&line_location_color)?;
+                let line_number_string = line.number().to_string();
+                let line_location_prefix = format!("{} | ", Pad(' ', line_number_string.len()));
+                write!(writer, "{} | ", line_number_string)?;
+                writer.reset()?;
+
+                write!(writer, "{}", line_prefix)?;
+                writer.set_color(&label_color)?;
+                write!(writer, "{}", line_marked)?;
+                writer.reset()?;
+                writeln!(writer, "{}", line_suffix)?;
+
+                if !supports_color || label.message.is_some() {
+                    writer.set_color(&line_location_color)?;
+                    write!(writer, "{}", line_location_prefix)?;
+                    writer.reset()?;
+
+                    writer.set_color(&label_color)?;
+                    write!(
+                        writer,
+                        "{}{}",
+                        Pad(' ', line_prefix.width()),
+                        Pad(mark, line_marked.width()),
+                    )?;
+                    writer.reset()?;
+
+                    if label.message.is_none() {
+                        writeln!(writer)?;
+                    }
+                }
+
+                match label.message {
+                    None => (),
+                    Some(ref label) => {
+                        writer.set_color(&label_color)?;
+                        writeln!(writer, " {}", label)?;
+                        writer.reset()?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[inline]
+pub fn green() -> ColorSpec {
+    color(Color::Green)
+}
+
+#[inline]
+pub fn green_bold() -> ColorSpec {
+    color_bold(Color::Green)
+}
+
+#[inline]
+pub fn yellow() -> ColorSpec {
+    color(Color::Yellow)
+}
+
+#[inline]
+pub fn yellow_bold() -> ColorSpec {
+    color_bold(Color::Yellow)
+}
+
+#[inline]
+pub fn white() -> ColorSpec {
+    color_bold(Color::White)
+}
+
+#[inline]
+pub fn cyan() -> ColorSpec {
+    if cfg!(windows) {
+        color(Color::Cyan)
+    } else {
+        color(Color::Blue)
+    }
+}
+
+#[inline]
+pub fn color(color: Color) -> ColorSpec {
+    let mut spec = ColorSpec::new();
+    spec.set_fg(Some(color));
+    spec
+}
+
+#[inline]
+pub fn color_bold(color: Color) -> ColorSpec {
+    let mut spec = ColorSpec::new();
+    spec.set_fg(Some(color)).set_bold(true).set_intense(true);
+    spec
+}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "frontend"
+version = "0.1.0"
+authors = ["Paul Schoenfelder <paulschoenfelder@gmail.com>", "Luke Imhoff <Kronic.Deth@gmail.com>"]
+readme = "README.md"
+publish = false
+edition = "2018"
+
+build = "build.rs"
+
+[dependencies]
+diagnostics = { path = "../diagnostics" }
+rustc-hash = "1.0"
+lalrpop-util = "0.16"
+glob = "0.2"
+termcolor = "0.3"
+failure = "0.1"
+itertools = "0.8"
+lazy_static = "1.2"
+
+[dependencies.rug]
+version = "1.2"
+default-features = false
+features = ["integer", "float", "rand"]
+
+[dev-dependencies]
+pretty_assertions = "0.5"
+
+[build-dependencies]
+lalrpop = "0.16"

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Paul Schoenfelder <paulschoenfelder@gmail.com>", "Luke Imhoff <Kroni
 readme = "README.md"
 publish = false
 edition = "2018"
+license = "../LICENSE.md"
 
 build = "build.rs"
 

--- a/frontend/build.rs
+++ b/frontend/build.rs
@@ -1,0 +1,10 @@
+extern crate lalrpop;
+
+fn main() {
+    lalrpop::Configuration::new()
+        .use_cargo_dir_conventions()
+        .process_file("src/parser/grammar.lalrpop")
+        .unwrap();
+
+    println!("cargo:rerun-if-changed=src/parser/grammar.lalrpop");
+}

--- a/frontend/src/arena.rs
+++ b/frontend/src/arena.rs
@@ -1,0 +1,622 @@
+#![allow(unused)]
+//! NOTE: Modified version of impl in rustc
+//!
+//! The arena, a fast but limited type of allocator.
+//!
+//! Arenas are a type of allocator that destroy the objects within, all at
+//! once, once the arena itself is destroyed. They do not support deallocation
+//! of individual objects while the arena itself is still alive. The benefit
+//! of an arena is very fast allocation; just a pointer bump.
+//!
+//! This crate implements `TypedArena`, a simple arena that can only hold
+//! objects of a single type.
+use core::cell::{Cell, RefCell};
+use core::cmp;
+use core::intrinsics;
+use core::marker::{PhantomData, Send};
+use core::mem;
+use core::ptr;
+use core::slice;
+
+use alloc::raw_vec::RawVec;
+use alloc::vec::Vec;
+
+/// An arena that can hold objects of only one type.
+pub struct TypedArena<T> {
+    /// A pointer to the next object to be allocated.
+    ptr: Cell<*mut T>,
+
+    /// A pointer to the end of the allocated area. When this pointer is
+    /// reached, a new chunk is allocated.
+    end: Cell<*mut T>,
+
+    /// A vector of arena chunks.
+    chunks: RefCell<Vec<TypedArenaChunk<T>>>,
+
+    /// Marker indicating that dropping the arena causes its owned
+    /// instances of `T` to be dropped.
+    _own: PhantomData<T>,
+}
+
+struct TypedArenaChunk<T> {
+    /// The raw storage for the arena chunk.
+    storage: RawVec<T>,
+}
+
+impl<T> TypedArenaChunk<T> {
+    #[inline]
+    unsafe fn new(capacity: usize) -> TypedArenaChunk<T> {
+        TypedArenaChunk {
+            storage: RawVec::with_capacity(capacity),
+        }
+    }
+
+    /// Destroys this arena chunk.
+    #[inline]
+    unsafe fn destroy(&mut self, len: usize) {
+        // The branch on needs_drop() is an -O1 performance optimization.
+        // Without the branch, dropping TypedArena<u8> takes linear time.
+        if mem::needs_drop::<T>() {
+            let mut start = self.start();
+            // Destroy all allocated objects.
+            for _ in 0..len {
+                ptr::drop_in_place(start);
+                start = start.offset(1);
+            }
+        }
+    }
+
+    // Returns a pointer to the first allocated object.
+    #[inline]
+    fn start(&self) -> *mut T {
+        self.storage.ptr()
+    }
+
+    // Returns a pointer to the end of the allocated space.
+    #[inline]
+    fn end(&self) -> *mut T {
+        unsafe {
+            if mem::size_of::<T>() == 0 {
+                // A pointer as large as possible for zero-sized elements.
+                !0 as *mut T
+            } else {
+                self.start().add(self.storage.cap())
+            }
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+const PAGE: usize = 4 * 1024;
+
+#[cfg(target_arch = "wasm32")]
+const PAGE: usize = 64 * 1024;
+
+impl<T> Default for TypedArena<T> {
+    /// Creates a new `TypedArena`.
+    fn default() -> TypedArena<T> {
+        TypedArena {
+            // We set both `ptr` and `end` to 0 so that the first call to
+            // alloc() will trigger a grow().
+            ptr: Cell::new(0 as *mut T),
+            end: Cell::new(0 as *mut T),
+            chunks: RefCell::new(Vec::new()),
+            _own: PhantomData,
+        }
+    }
+}
+
+impl<T> TypedArena<T> {
+    pub fn in_arena(&self, ptr: *const T) -> bool {
+        let ptr = ptr as *const T as *mut T;
+
+        self.chunks
+            .borrow()
+            .iter()
+            .any(|chunk| chunk.start() <= ptr && ptr < chunk.end())
+    }
+    /// Allocates an object in the `TypedArena`, returning a reference to it.
+    #[inline]
+    pub fn alloc(&self, object: T) -> &mut T {
+        if self.ptr == self.end {
+            self.grow(1)
+        }
+
+        unsafe {
+            if mem::size_of::<T>() == 0 {
+                self.ptr
+                    .set(intrinsics::arith_offset(self.ptr.get() as *mut u8, 1) as *mut T);
+                let ptr = mem::align_of::<T>() as *mut T;
+                // Don't drop the object. This `write` is equivalent to `forget`.
+                ptr::write(ptr, object);
+                &mut *ptr
+            } else {
+                let ptr = self.ptr.get();
+                // Advance the pointer.
+                self.ptr.set(self.ptr.get().offset(1));
+                // Write into uninitialized memory.
+                ptr::write(ptr, object);
+                &mut *ptr
+            }
+        }
+    }
+
+    /// Allocates a slice of objects that are copied into the `TypedArena`, returning a mutable
+    /// reference to it. Will panic if passed a zero-sized types.
+    ///
+    /// Panics:
+    ///
+    ///  - Zero-sized types
+    ///  - Zero-length slices
+    #[inline]
+    pub fn alloc_slice(&self, slice: &[T]) -> &mut [T]
+    where
+        T: Copy,
+    {
+        assert!(mem::size_of::<T>() != 0);
+        assert!(slice.len() != 0);
+
+        let available_capacity_bytes = self.end.get() as usize - self.ptr.get() as usize;
+        let at_least_bytes = slice.len() * mem::size_of::<T>();
+        if available_capacity_bytes < at_least_bytes {
+            self.grow(slice.len());
+        }
+
+        unsafe {
+            let start_ptr = self.ptr.get();
+            let arena_slice = slice::from_raw_parts_mut(start_ptr, slice.len());
+            self.ptr.set(start_ptr.add(arena_slice.len()));
+            arena_slice.copy_from_slice(slice);
+            arena_slice
+        }
+    }
+
+    /// Grows the arena.
+    #[inline(never)]
+    #[cold]
+    fn grow(&self, n: usize) {
+        unsafe {
+            let mut chunks = self.chunks.borrow_mut();
+            let (chunk, mut new_capacity);
+            if let Some(last_chunk) = chunks.last_mut() {
+                let used_bytes = self.ptr.get() as usize - last_chunk.start() as usize;
+                let currently_used_cap = used_bytes / mem::size_of::<T>();
+                if last_chunk.storage.reserve_in_place(currently_used_cap, n) {
+                    self.end.set(last_chunk.end());
+                    return;
+                } else {
+                    new_capacity = last_chunk.storage.cap();
+                    loop {
+                        new_capacity = new_capacity.checked_mul(2).unwrap();
+                        if new_capacity >= currently_used_cap + n {
+                            break;
+                        }
+                    }
+                }
+            } else {
+                let elem_size = cmp::max(1, mem::size_of::<T>());
+                new_capacity = cmp::max(n, PAGE / elem_size);
+            }
+            chunk = TypedArenaChunk::<T>::new(new_capacity);
+            self.ptr.set(chunk.start());
+            self.end.set(chunk.end());
+            chunks.push(chunk);
+        }
+    }
+
+    /// Clears the arena. Deallocates all but the longest chunk which may be reused.
+    pub fn clear(&mut self) {
+        unsafe {
+            // Clear the last chunk, which is partially filled.
+            let mut chunks_borrow = self.chunks.borrow_mut();
+            if let Some(mut last_chunk) = chunks_borrow.last_mut() {
+                self.clear_last_chunk(&mut last_chunk);
+                let len = chunks_borrow.len();
+                // If `T` is ZST, code below has no effect.
+                for mut chunk in chunks_borrow.drain(..len - 1) {
+                    let cap = chunk.storage.cap();
+                    chunk.destroy(cap);
+                }
+            }
+        }
+    }
+
+    // Drops the contents of the last chunk. The last chunk is partially empty, unlike all other
+    // chunks.
+    fn clear_last_chunk(&self, last_chunk: &mut TypedArenaChunk<T>) {
+        // Determine how much was filled.
+        let start = last_chunk.start() as usize;
+        // We obtain the value of the pointer to the first uninitialized element.
+        let end = self.ptr.get() as usize;
+        // We then calculate the number of elements to be dropped in the last chunk,
+        // which is the filled area's length.
+        let diff = if mem::size_of::<T>() == 0 {
+            // `T` is ZST. It can't have a drop flag, so the value here doesn't matter. We get
+            // the number of zero-sized values in the last and only chunk, just out of caution.
+            // Recall that `end` was incremented for each allocated value.
+            end - start
+        } else {
+            (end - start) / mem::size_of::<T>()
+        };
+        // Pass that to the `destroy` method.
+        unsafe {
+            last_chunk.destroy(diff);
+        }
+        // Reset the chunk.
+        self.ptr.set(last_chunk.start());
+    }
+}
+
+unsafe impl<#[may_dangle] T> Drop for TypedArena<T> {
+    fn drop(&mut self) {
+        unsafe {
+            // Determine how much was filled.
+            let mut chunks_borrow = self.chunks.borrow_mut();
+            if let Some(mut last_chunk) = chunks_borrow.pop() {
+                // Drop the contents of the last chunk.
+                self.clear_last_chunk(&mut last_chunk);
+                // The last chunk will be dropped. Destroy all other chunks.
+                for chunk in chunks_borrow.iter_mut() {
+                    let cap = chunk.storage.cap();
+                    chunk.destroy(cap);
+                }
+            }
+            // RawVec handles deallocation of `last_chunk` and `self.chunks`.
+        }
+    }
+}
+
+unsafe impl<T: Send> Send for TypedArena<T> {}
+
+pub struct DroplessArena {
+    /// A pointer to the next object to be allocated.
+    ptr: Cell<*mut u8>,
+
+    /// A pointer to the end of the allocated area. When this pointer is
+    /// reached, a new chunk is allocated.
+    end: Cell<*mut u8>,
+
+    /// A vector of arena chunks.
+    chunks: RefCell<Vec<TypedArenaChunk<u8>>>,
+}
+
+unsafe impl Send for DroplessArena {}
+
+impl Default for DroplessArena {
+    #[inline]
+    fn default() -> DroplessArena {
+        DroplessArena {
+            ptr: Cell::new(0 as *mut u8),
+            end: Cell::new(0 as *mut u8),
+            chunks: Default::default(),
+        }
+    }
+}
+
+impl DroplessArena {
+    pub fn in_arena<T: ?Sized>(&self, ptr: *const T) -> bool {
+        let ptr = ptr as *const u8 as *mut u8;
+
+        self.chunks
+            .borrow()
+            .iter()
+            .any(|chunk| chunk.start() <= ptr && ptr < chunk.end())
+    }
+
+    #[inline]
+    fn align(&self, align: usize) {
+        let final_address = ((self.ptr.get() as usize) + align - 1) & !(align - 1);
+        self.ptr.set(final_address as *mut u8);
+        assert!(self.ptr <= self.end);
+    }
+
+    #[inline(never)]
+    #[cold]
+    fn grow(&self, needed_bytes: usize) {
+        unsafe {
+            let mut chunks = self.chunks.borrow_mut();
+            let (chunk, mut new_capacity);
+            if let Some(last_chunk) = chunks.last_mut() {
+                let used_bytes = self.ptr.get() as usize - last_chunk.start() as usize;
+                if last_chunk
+                    .storage
+                    .reserve_in_place(used_bytes, needed_bytes)
+                {
+                    self.end.set(last_chunk.end());
+                    return;
+                } else {
+                    new_capacity = last_chunk.storage.cap();
+                    loop {
+                        new_capacity = new_capacity.checked_mul(2).unwrap();
+                        if new_capacity >= used_bytes + needed_bytes {
+                            break;
+                        }
+                    }
+                }
+            } else {
+                new_capacity = cmp::max(needed_bytes, PAGE);
+            }
+            chunk = TypedArenaChunk::<u8>::new(new_capacity);
+            self.ptr.set(chunk.start());
+            self.end.set(chunk.end());
+            chunks.push(chunk);
+        }
+    }
+
+    #[inline]
+    pub unsafe fn alloc_raw(&self, bytes: usize, align: usize) -> *mut u8 {
+        assert!(bytes != 0);
+
+        self.align(align);
+
+        let future_end = intrinsics::arith_offset(self.ptr.get(), bytes as isize);
+        if (future_end as *mut u8) >= self.end.get() {
+            self.grow(bytes);
+        }
+
+        let ptr = self.ptr.get();
+        // Set the pointer past ourselves
+        self.ptr
+            .set(intrinsics::arith_offset(self.ptr.get(), bytes as isize) as *mut u8);
+
+        ptr
+    }
+
+    #[inline]
+    pub fn alloc_copy<T>(&self, object: T) -> &mut T {
+        assert!(!mem::needs_drop::<T>());
+
+        unsafe {
+            let mem = self.alloc_raw(mem::size_of::<T>(), mem::align_of::<T>()) as *mut T;
+
+            // Write into uninitialized memory.
+            ptr::write(mem, object);
+            &mut *mem
+        }
+    }
+
+    /// Allocates a slice of objects that are copied into the `DroplessArena`, returning a mutable
+    /// reference to it. Will panic if passed a zero-sized type.
+    ///
+    /// Panics:
+    ///
+    ///  - Zero-sized types
+    ///  - Zero-length slices
+    #[inline]
+    pub fn alloc_slice<T>(&self, slice: &[T]) -> &mut [T]
+    where
+        T: Copy,
+    {
+        assert!(!mem::needs_drop::<T>());
+        assert!(mem::size_of::<T>() != 0);
+        assert!(!slice.is_empty());
+
+        unsafe {
+            let mem = self.alloc_raw(slice.len() * mem::size_of::<T>(), mem::align_of::<T>())
+                as *mut _ as *mut T;
+
+            let arena_slice = slice::from_raw_parts_mut(mem, slice.len());
+            arena_slice.copy_from_slice(slice);
+            arena_slice
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TypedArena;
+    use alloc::boxed::Box;
+    use alloc::string::String;
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use core::cell::Cell;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    use test::Bencher;
+
+    #[allow(dead_code)]
+    #[derive(Debug, Eq, PartialEq)]
+    struct Point {
+        x: i32,
+        y: i32,
+        z: i32,
+    }
+
+    #[test]
+    pub fn test_unused() {
+        let arena: TypedArena<Point> = TypedArena::default();
+        assert!(arena.chunks.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_arena_alloc_nested() {
+        struct Inner {
+            value: u8,
+        }
+        struct Outer<'a> {
+            inner: &'a Inner,
+        }
+        enum EI<'e> {
+            I(Inner),
+            O(Outer<'e>),
+        }
+
+        struct Wrap<'a>(TypedArena<EI<'a>>);
+
+        impl<'a> Wrap<'a> {
+            fn alloc_inner<F: Fn() -> Inner>(&self, f: F) -> &Inner {
+                let r: &EI = self.0.alloc(EI::I(f()));
+                if let &EI::I(ref i) = r {
+                    i
+                } else {
+                    panic!("mismatch");
+                }
+            }
+            fn alloc_outer<F: Fn() -> Outer<'a>>(&self, f: F) -> &Outer {
+                let r: &EI = self.0.alloc(EI::O(f()));
+                if let &EI::O(ref o) = r {
+                    o
+                } else {
+                    panic!("mismatch");
+                }
+            }
+        }
+
+        let arena = Wrap(TypedArena::default());
+
+        let result = arena.alloc_outer(|| Outer {
+            inner: arena.alloc_inner(|| Inner { value: 10 }),
+        });
+
+        assert_eq!(result.inner.value, 10);
+    }
+
+    #[test]
+    pub fn test_copy() {
+        let arena = TypedArena::default();
+        for _ in 0..100000 {
+            arena.alloc(Point { x: 1, y: 2, z: 3 });
+        }
+    }
+
+    #[bench]
+    pub fn bench_copy(b: &mut Bencher) {
+        let arena = TypedArena::default();
+        b.iter(|| arena.alloc(Point { x: 1, y: 2, z: 3 }))
+    }
+
+    #[bench]
+    pub fn bench_copy_nonarena(b: &mut Bencher) {
+        b.iter(|| {
+            let _: Box<_> = Box::new(Point { x: 1, y: 2, z: 3 });
+        })
+    }
+
+    #[allow(dead_code)]
+    struct Noncopy {
+        string: String,
+        array: Vec<i32>,
+    }
+
+    #[test]
+    pub fn test_noncopy() {
+        let arena = TypedArena::default();
+        for _ in 0..100000 {
+            arena.alloc(Noncopy {
+                string: String::from("hello world"),
+                array: vec![1, 2, 3, 4, 5],
+            });
+        }
+    }
+
+    #[test]
+    pub fn test_typed_arena_zero_sized() {
+        let arena = TypedArena::default();
+        for _ in 0..100000 {
+            arena.alloc(());
+        }
+    }
+
+    #[test]
+    pub fn test_typed_arena_clear() {
+        let mut arena = TypedArena::default();
+        for _ in 0..10 {
+            arena.clear();
+            for _ in 0..10000 {
+                arena.alloc(Point { x: 1, y: 2, z: 3 });
+            }
+        }
+    }
+
+    #[bench]
+    pub fn bench_typed_arena_clear(b: &mut Bencher) {
+        let mut arena = TypedArena::default();
+        b.iter(|| {
+            arena.alloc(Point { x: 1, y: 2, z: 3 });
+            arena.clear();
+        })
+    }
+
+    // Drop tests
+
+    struct DropCounter<'a> {
+        count: &'a Cell<u32>,
+    }
+
+    impl<'a> Drop for DropCounter<'a> {
+        fn drop(&mut self) {
+            self.count.set(self.count.get() + 1);
+        }
+    }
+
+    #[test]
+    fn test_typed_arena_drop_count() {
+        let counter = Cell::new(0);
+        {
+            let arena: TypedArena<DropCounter> = TypedArena::default();
+            for _ in 0..100 {
+                // Allocate something with drop glue to make sure it doesn't leak.
+                arena.alloc(DropCounter { count: &counter });
+            }
+        };
+        assert_eq!(counter.get(), 100);
+    }
+
+    #[test]
+    fn test_typed_arena_drop_on_clear() {
+        let counter = Cell::new(0);
+        let mut arena: TypedArena<DropCounter> = TypedArena::default();
+        for i in 0..10 {
+            for _ in 0..100 {
+                // Allocate something with drop glue to make sure it doesn't leak.
+                arena.alloc(DropCounter { count: &counter });
+            }
+            arena.clear();
+            assert_eq!(counter.get(), i * 100 + 100);
+        }
+    }
+
+    static DROP_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    struct SmallDroppable;
+
+    impl Drop for SmallDroppable {
+        fn drop(&mut self) {
+            DROP_COUNTER.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn test_typed_arena_drop_small_count() {
+        DROP_COUNTER.store(0, Ordering::SeqCst);
+        {
+            let arena: TypedArena<SmallDroppable> = TypedArena::default();
+            for _ in 0..100 {
+                // Allocate something with drop glue to make sure it doesn't leak.
+                arena.alloc(SmallDroppable);
+            }
+            // dropping
+        };
+        assert_eq!(DROP_COUNTER.load(Ordering::SeqCst), 100);
+    }
+
+    #[bench]
+    pub fn bench_noncopy(b: &mut Bencher) {
+        let arena = TypedArena::default();
+        b.iter(|| {
+            arena.alloc(Noncopy {
+                string: String::from("hello world"),
+                array: vec![1, 2, 3, 4, 5],
+            })
+        })
+    }
+
+    #[bench]
+    pub fn bench_noncopy_nonarena(b: &mut Bencher) {
+        b.iter(|| {
+            let _: Box<_> = Box::new(Noncopy {
+                string: String::from("hello world"),
+                array: vec![1, 2, 3, 4, 5],
+            });
+        })
+    }
+}

--- a/frontend/src/lexer.rs
+++ b/frontend/src/lexer.rs
@@ -1,0 +1,23 @@
+//! A fairly basic lexer for Erlang
+
+mod errors;
+mod lexer;
+mod scanner;
+mod source;
+mod symbol;
+mod token;
+
+pub use self::errors::{LexicalError, TokenConvertError};
+pub use self::lexer::Lexer;
+pub use self::scanner::Scanner;
+pub use self::source::{FileMapSource, Source, SourceError};
+pub use self::symbol::{symbols, SYMBOL_TABLE};
+pub use self::symbol::{Ident, InternedString, LocalInternedString, Symbol};
+pub use self::token::{AtomToken, IdentToken, StringToken, SymbolToken, TokenType};
+pub use self::token::{LexicalToken, Token};
+
+/// The type that serves as an `Item` for the lexer iterator.
+pub type Lexed = Result<LexicalToken, LexicalError>;
+
+/// The result type produced by TryFrom<LexicalToken>
+pub type TokenConvertResult<T> = Result<T, TokenConvertError>;

--- a/frontend/src/lexer/errors.rs
+++ b/frontend/src/lexer/errors.rs
@@ -1,0 +1,91 @@
+use std::hash::{Hash, Hasher};
+
+use failure::Fail;
+
+use diagnostics::{ByteIndex, ByteSpan, Diagnostic, Label};
+
+use super::token::{Token, TokenType};
+
+/// An enum of possible errors that can occur during lexing.
+#[derive(Fail, Clone, Debug, PartialEq)]
+pub enum LexicalError {
+    #[fail(display = "{}", reason)]
+    InvalidFloat { span: ByteSpan, reason: String },
+
+    #[fail(display = "{}", reason)]
+    InvalidRadix { span: ByteSpan, reason: String },
+
+    /// Occurs when a string literal is not closed (e.g. `"this is an unclosed string`)
+    /// It is also implicit that hitting this error means we've reached EOF, as we'll scan the
+    /// entire input looking for the closing quote
+    #[fail(display = "Unclosed string literal")]
+    UnclosedString { span: ByteSpan },
+
+    /// Like UnclosedStringLiteral, but for quoted atoms
+    #[fail(display = "Unclosed atom literal")]
+    UnclosedAtom { span: ByteSpan },
+
+    /// Occurs when an escape sequence is encountered but the code is unsupported or unrecognized
+    #[fail(display = "{}", reason)]
+    InvalidEscape { span: ByteSpan, reason: String },
+
+    /// Occurs when we encounter an unexpected character
+    #[fail(display = "Encountered unexpected character '{}'", found)]
+    UnexpectedCharacter { start: ByteIndex, found: char },
+}
+impl Hash for LexicalError {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let id = match *self {
+            LexicalError::InvalidFloat { .. } => 0,
+            LexicalError::InvalidRadix { .. } => 1,
+            LexicalError::UnclosedString { .. } => 2,
+            LexicalError::UnclosedAtom { .. } => 3,
+            LexicalError::InvalidEscape { .. } => 4,
+            LexicalError::UnexpectedCharacter { .. } => 5,
+        };
+        id.hash(state);
+    }
+}
+impl LexicalError {
+    /// Return the source span for this error
+    pub fn span(&self) -> ByteSpan {
+        match *self {
+            LexicalError::InvalidFloat { span, .. } => span,
+            LexicalError::InvalidRadix { span, .. } => span,
+            LexicalError::UnclosedString { span, .. } => span,
+            LexicalError::UnclosedAtom { span, .. } => span,
+            LexicalError::InvalidEscape { span, .. } => span,
+            LexicalError::UnexpectedCharacter { start, .. } => ByteSpan::new(start, start),
+        }
+    }
+
+    /// Get diagnostic for display
+    pub fn to_diagnostic(&self) -> Diagnostic {
+        let span = self.span();
+        let msg = self.to_string();
+        match *self {
+            LexicalError::InvalidFloat { .. } => Diagnostic::new_error("invalid float literal")
+                .with_label(Label::new_primary(span).with_message(msg)),
+            LexicalError::InvalidRadix { .. } => {
+                Diagnostic::new_error("invalid radix value for integer literal")
+                    .with_label(Label::new_primary(span).with_message(msg))
+            }
+            LexicalError::InvalidEscape { .. } => Diagnostic::new_error("invalid escape sequence")
+                .with_label(Label::new_primary(span).with_message(msg)),
+            LexicalError::UnexpectedCharacter { .. } => {
+                Diagnostic::new_error("unexpected character")
+                    .with_label(Label::new_primary(span).with_message(msg))
+            }
+            _ => Diagnostic::new_error(msg).with_label(Label::new_primary(span)),
+        }
+    }
+}
+
+/// Produced when converting from LexicalToken to {Atom,Ident,String,Symbol}Token
+#[derive(Fail, Debug, Clone)]
+#[fail(display = "expected token of {}, got {}", expected, token)]
+pub struct TokenConvertError {
+    pub span: ByteSpan,
+    pub token: Token,
+    pub expected: TokenType,
+}

--- a/frontend/src/lexer/lexer.rs
+++ b/frontend/src/lexer/lexer.rs
@@ -1,0 +1,896 @@
+use std::error::Error;
+use std::str::FromStr;
+
+use rug::Integer;
+
+use diagnostics::{ByteIndex, ByteOffset, ByteSpan};
+
+use super::errors::LexicalError;
+use super::scanner::Scanner;
+use super::source::Source;
+use super::token::*;
+use super::{Lexed, Symbol};
+
+macro_rules! pop {
+    ($lex:ident) => {{
+        $lex.skip();
+    }};
+    ($lex:ident, $code:expr) => {{
+        $lex.skip();
+        $code
+    }};
+}
+
+macro_rules! pop2 {
+    ($lex:ident) => {{
+        $lex.skip();
+        $lex.skip();
+    }};
+    ($lex:ident, $code:expr) => {{
+        $lex.skip();
+        $lex.skip();
+        $code
+    }};
+}
+
+macro_rules! pop3 {
+    ($lex:ident) => {{
+        $lex.skip();
+        $lex.skip();
+        $lex.skip()
+    }};
+    ($lex:ident, $code:expr) => {{
+        $lex.skip();
+        $lex.skip();
+        $lex.skip();
+        $code
+    }};
+}
+
+/// The lexer that is used to perform lexical analysis on the Erlang grammar. The lexer implements
+/// the `Iterator` trait, so in order to retrieve the tokens, you simply have to iterate over it.
+///
+/// # Errors
+///
+/// Because the lexer is implemented as an iterator over tokens, this means that you can continue
+/// to get tokens even if a lexical error occurs. The lexer will attempt to recover from an error
+/// by injecting tokens it expects.
+///
+/// If an error is unrecoverable, the lexer will continue to produce tokens, but there is no
+/// guarantee that parsing them will produce meaningful results, it is primarily to assist in
+/// gathering as many errors as possible.
+pub struct Lexer<S> {
+    /// The scanner produces a sequence of chars + location, and can be controlled
+    /// The location produces is a ByteIndex
+    scanner: Scanner<S>,
+
+    /// The most recent token to be lexed.
+    /// At the start and end, this should be Token::EOF
+    token: Token,
+
+    /// The position in the input where the current token starts
+    /// At the start this will be the byte index of the beginning of the input
+    token_start: ByteIndex,
+
+    /// The position in the input where the current token ends
+    /// At the start this will be the byte index of the beginning of the input
+    token_end: ByteIndex,
+
+    /// When we have reached true EOF, this gets set to true, and the only token
+    /// produced after that point is Token::EOF, or None, depending on how you are
+    /// consuming the lexer
+    eof: bool,
+}
+
+impl<S> Lexer<S>
+where
+    S: Source,
+{
+    /// Produces an instance of the lexer with the lexical analysis to be performed on the `input`
+    /// string. Note that no lexical analysis occurs until the lexer has been iterated over.
+    pub fn new(scanner: Scanner<S>) -> Self {
+        let start = scanner.start();
+        let mut lexer = Lexer {
+            scanner,
+            token: Token::EOF,
+            token_start: start + ByteOffset(0),
+            token_end: start + ByteOffset(0),
+            eof: false,
+        };
+        lexer.advance();
+        lexer
+    }
+
+    pub fn lex(&mut self) -> Option<<Self as Iterator>::Item> {
+        if self.eof && self.token == Token::EOF {
+            return None;
+        }
+
+        let token = std::mem::replace(&mut self.token, Token::EOF);
+        let result = if let Token::Error(err) = token {
+            Some(Err(err))
+        } else {
+            Some(Ok(LexicalToken(
+                self.token_start.clone(),
+                token,
+                self.token_end.clone(),
+            )))
+        };
+
+        self.advance();
+
+        result
+    }
+
+    fn advance(&mut self) {
+        self.advance_start();
+        self.token = self.tokenize();
+    }
+
+    #[inline]
+    fn advance_start(&mut self) {
+        let mut position: ByteIndex;
+        loop {
+            let (pos, c) = self.scanner.read();
+
+            position = pos;
+
+            if c == '\0' {
+                self.eof = true;
+                return;
+            }
+
+            if c.is_whitespace() {
+                self.scanner.advance();
+                continue;
+            }
+
+            break;
+        }
+
+        self.token_start = position;
+    }
+
+    #[inline]
+    fn pop(&mut self) -> char {
+        let (pos, c) = self.scanner.pop();
+        self.token_end = pos + ByteOffset::from_char_utf8(c);
+        c
+    }
+
+    #[inline]
+    fn peek(&mut self) -> char {
+        let (_, c) = self.scanner.peek();
+        c
+    }
+
+    #[inline]
+    fn peek_next(&mut self) -> char {
+        let (_, c) = self.scanner.peek_next();
+        c
+    }
+
+    #[inline]
+    fn read(&mut self) -> char {
+        let (_, c) = self.scanner.read();
+        c
+    }
+
+    #[inline]
+    fn skip(&mut self) {
+        self.pop();
+    }
+
+    /// Get the span for the current token in `Source`.
+    #[inline]
+    pub fn span(&self) -> ByteSpan {
+        ByteSpan::new(self.token_start, self.token_end)
+    }
+
+    /// Get a string slice of the current token.
+    #[inline]
+    fn slice(&self) -> &str {
+        self.scanner.slice(self.span())
+    }
+
+    #[inline]
+    fn slice_span(&self, span: ByteSpan) -> &str {
+        self.scanner.slice(span)
+    }
+
+    #[inline]
+    fn skip_whitespace(&mut self) {
+        let mut c: char;
+        loop {
+            c = self.read();
+
+            if !c.is_whitespace() {
+                break;
+            }
+
+            self.skip();
+        }
+    }
+
+    fn tokenize(&mut self) -> Token {
+        let c = self.read();
+
+        if c == '%' {
+            self.skip();
+            return self.lex_comment();
+        }
+
+        if c == '\0' {
+            self.eof = true;
+            return Token::EOF;
+        }
+
+        if c.is_whitespace() {
+            self.skip_whitespace();
+        }
+
+        match self.read() {
+            ',' => pop!(self, Token::Comma),
+            ';' => pop!(self, Token::Semicolon),
+            '_' => self.lex_identifier(),
+            '0'...'9' => self.lex_number(),
+            'a'...'z' => self.lex_bare_atom(),
+            'A'...'Z' => self.lex_identifier(),
+            '#' => pop!(self, Token::Pound),
+            '*' => pop!(self, Token::Star),
+            '!' => pop!(self, Token::Bang),
+            '[' => pop!(self, Token::LBracket),
+            ']' => pop!(self, Token::RBracket),
+            '(' => pop!(self, Token::LParen),
+            ')' => pop!(self, Token::RParen),
+            '{' => pop!(self, Token::LBrace),
+            '}' => pop!(self, Token::RBrace),
+            '?' => match self.peek() {
+                '?' => pop2!(self, Token::DoubleQuestion),
+                _ => pop!(self, Token::Question),
+            },
+            '-' => match self.peek() {
+                '-' => pop2!(self, Token::MinusMinus),
+                '>' => pop2!(self, Token::RightStab),
+                n if n.is_digit(10) => self.lex_number(),
+                _ => pop!(self, Token::Minus),
+            },
+            '$' => {
+                self.skip();
+                let c = self.pop();
+                if c == '\\' {
+                    return match self.lex_escape_sequence() {
+                        Ok(Token::Char(c)) => Token::Char(c),
+                        Ok(Token::Integer(i)) => match std::char::from_u32(i as u32) {
+                            Some(c) => Token::Char(c),
+                            None => Token::Error(LexicalError::InvalidEscape {
+                                span: self.span(),
+                                reason: format!("the integer value '{}' is not a valid char", i),
+                            }),
+                        },
+                        Ok(Token::BigInteger(i)) => Token::Error(LexicalError::InvalidEscape {
+                            span: self.span(),
+                            reason: format!("the integer value '{}' is not a valid char", i),
+                        }),
+                        Ok(_) => panic!("internal error: unhandled escape sequence in lexer"),
+                        Err(e) => Token::Error(e),
+                    };
+                }
+                Token::Char(c)
+            }
+            '"' => self.lex_string(),
+            '\'' => match self.lex_string() {
+                Token::String(s) => Token::Atom(s),
+                other => other,
+            },
+            ':' => match self.peek() {
+                '=' => pop2!(self, Token::ColonEqual),
+                ':' => pop2!(self, Token::ColonColon),
+                _ => pop!(self, Token::Colon),
+            },
+            '+' => {
+                if self.peek() == '+' {
+                    pop2!(self, Token::PlusPlus)
+                } else {
+                    pop!(self, Token::Plus)
+                }
+            }
+            '/' => {
+                if self.peek() == '=' {
+                    pop2!(self, Token::IsNotEqual)
+                } else {
+                    pop!(self, Token::Slash)
+                }
+            }
+            '=' => match self.peek() {
+                '=' => pop2!(self, Token::IsEqual),
+                '>' => pop2!(self, Token::RightArrow),
+                '/' => {
+                    if self.peek_next() == '=' {
+                        pop3!(self, Token::IsExactlyNotEqual)
+                    } else {
+                        Token::Error(LexicalError::UnexpectedCharacter {
+                            start: self.span().start(),
+                            found: self.peek_next(),
+                        })
+                    }
+                }
+                _ => pop!(self, Token::Equals),
+            },
+            '<' => match self.peek() {
+                '<' => pop2!(self, Token::BinaryStart),
+                '-' => pop2!(self, Token::LeftStab),
+                '=' => pop2!(self, Token::LeftArrow),
+                _ => pop!(self, Token::IsLessThan),
+            },
+            '>' => match self.peek() {
+                '>' => pop2!(self, Token::BinaryEnd),
+                '=' => pop2!(self, Token::IsGreaterThanOrEqual),
+                _ => pop!(self, Token::IsGreaterThan),
+            },
+            '|' => {
+                if self.peek() == '|' {
+                    pop2!(self, Token::BarBar)
+                } else {
+                    pop!(self, Token::Bar)
+                }
+            }
+            '.' => {
+                if self.peek() == '.' {
+                    if self.peek_next() == '.' {
+                        pop3!(self, Token::DotDotDot)
+                    } else {
+                        pop2!(self, Token::DotDot)
+                    }
+                } else {
+                    pop!(self, Token::Dot)
+                }
+            }
+            '\\' => {
+                // Allow escaping newlines
+                let c = self.peek();
+                if c == '\n' {
+                    pop2!(self);
+                    return self.tokenize();
+                }
+                return match self.lex_escape_sequence() {
+                    Ok(t) => t,
+                    Err(e) => Token::Error(e),
+                };
+            }
+            c => Token::Error(LexicalError::UnexpectedCharacter {
+                start: self.span().start(),
+                found: c,
+            }),
+        }
+    }
+
+    fn lex_comment(&mut self) -> Token {
+        let mut c = self.read();
+        // If there is another '%', then this is a regular comment line
+        if c == '%' {
+            self.skip();
+
+            loop {
+                c = self.read();
+
+                if c == '\n' {
+                    break;
+                }
+
+                if c == '\0' {
+                    self.eof = true;
+                    break;
+                }
+
+                self.skip();
+            }
+
+            return Token::Comment;
+        }
+
+        // If no '%', then we should check for an Edoc tag, first skip all whitespace and advance
+        // the token start
+        self.skip_whitespace();
+
+        // See if this is an Edoc tag
+        c = self.read();
+        if c == '@' {
+            if self.peek().is_ascii_alphabetic() {
+                self.skip();
+
+                // Get the tag identifier
+                self.lex_identifier();
+                // Skip any leading whitespace in the value
+                self.skip_whitespace();
+                // Get value
+                loop {
+                    c = self.read();
+
+                    if c == '\n' {
+                        break;
+                    }
+
+                    if c == '\0' {
+                        self.eof = true;
+                        break;
+                    }
+
+                    self.skip();
+                }
+                return Token::Edoc;
+            }
+        }
+
+        // If we reach here, its a normal comment
+        loop {
+            if c == '\n' {
+                break;
+            }
+
+            if c == '\0' {
+                self.eof = true;
+                break;
+            }
+
+            self.skip();
+            c = self.read();
+        }
+
+        return Token::Comment;
+    }
+
+    #[inline]
+    fn lex_escape_sequence(&mut self) -> Result<Token, LexicalError> {
+        let mut c = self.pop();
+        debug_assert_eq!(c, '\\');
+
+        match self.pop() {
+            'n' => Ok(Token::Char('\n')),
+            'r' => Ok(Token::Char('\r')),
+            't' => Ok(Token::Char('\t')),
+            'b' => Ok(Token::Char('\x08')),
+            // TODO: Figure out why Erlang lexes this as an escape: 'd' => Some('\d'),
+            'e' => Ok(Token::Char('\x1B')),
+            'f' => Ok(Token::Char('\x0C')),
+            's' => Ok(Token::Char(' ')),
+            'v' => Ok(Token::Char('\x0B')),
+            '\'' => Ok(Token::Char('\'')),
+            '"' => Ok(Token::Char('"')),
+            '\\' => Ok(Token::Char('\\')),
+            // Possible octal escape
+            '0' => {
+                c = self.read();
+                if c.is_digit(8) {
+                    let mut num = String::new();
+                    while self.read().is_digit(8) {
+                        num.push(self.pop());
+                    }
+                    return Ok(to_integer_literal(&num, 8));
+                } else {
+                    Ok(Token::Char('\0'))
+                }
+            }
+            // Hex escape
+            'x' => {
+                c = self.read();
+                // \xXY
+                if c.is_digit(16) {
+                    let mut num = String::new();
+                    num.push(self.pop());
+                    c = self.read();
+                    if c.is_digit(16) {
+                        num.push(self.pop());
+                        return Ok(to_integer_literal(&num, 16));
+                    } else {
+                        return Err(LexicalError::InvalidEscape {
+                            span: self.span(),
+                            reason: "invalid hex escape, expected hex digit".to_string(),
+                        });
+                    }
+                } else if c == '{' {
+                    self.skip();
+                    let mut num = String::new();
+                    while self.read().is_digit(16) {
+                        num.push(self.pop());
+                    }
+                    if self.read() == '}' {
+                        self.skip();
+                        if num.len() == 0 {
+                            return Err(LexicalError::InvalidEscape {
+                                span: self.span(),
+                                reason: "invalid hex escape, must be at least one digit"
+                                    .to_string(),
+                            });
+                        }
+                        return Ok(to_integer_literal(&num, 16));
+                    } else {
+                        Err(LexicalError::InvalidEscape {
+                            span: self.span(),
+                            reason: "invalid hex escape, no closing '}'".to_string(),
+                        })
+                    }
+                } else {
+                    Err(LexicalError::InvalidEscape {
+                        span: self.span(),
+                        reason: "invalid hex escape, expected hex digit or '{'".to_string(),
+                    })
+                }
+            }
+            _ => Err(LexicalError::InvalidEscape {
+                span: self.span(),
+                reason: "invalid escape, unrecognized sequence".to_string(),
+            }),
+        }
+    }
+
+    #[inline]
+    fn lex_string(&mut self) -> Token {
+        let quote = self.pop();
+        debug_assert!(quote == '"' || quote == '\'');
+        loop {
+            match self.read() {
+                '\\' => match self.lex_escape_sequence() {
+                    Ok(_c) => (),
+                    Err(err) => return Token::Error(err),
+                },
+                '\0' if quote == '"' => {
+                    return Token::Error(LexicalError::UnclosedString { span: self.span() });
+                }
+                '\0' if quote == '\'' => {
+                    return Token::Error(LexicalError::UnclosedAtom { span: self.span() });
+                }
+                c if c == quote => {
+                    let symbol =
+                        Symbol::intern(self.slice_span(self.span().shrink_front(ByteOffset(1))));
+                    let token = Token::String(symbol);
+                    self.skip();
+                    return token;
+                }
+                _ => {
+                    self.skip();
+                    continue;
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn lex_identifier(&mut self) -> Token {
+        let c = self.pop();
+        debug_assert!(c == '_' || c.is_ascii_alphabetic());
+
+        loop {
+            match self.read() {
+                '_' => self.skip(),
+                '@' => self.skip(),
+                '0'...'9' => self.skip(),
+                c if c.is_alphabetic() => self.skip(),
+                _ => break,
+            }
+        }
+        Token::Ident(Symbol::intern(self.slice()))
+    }
+
+    #[inline]
+    fn lex_bare_atom(&mut self) -> Token {
+        let c = self.pop();
+        debug_assert!(c.is_ascii_lowercase());
+
+        loop {
+            match self.read() {
+                '_' => self.skip(),
+                '@' => self.skip(),
+                '0'...'9' => self.skip(),
+                c if c.is_alphabetic() => self.skip(),
+                _ => break,
+            }
+        }
+        Token::from_bare_atom(self.slice())
+    }
+
+    #[inline]
+    fn lex_number(&mut self) -> Token {
+        let mut num = String::new();
+        let mut c = self.pop();
+        debug_assert!(c == '-' || c == '+' || c.is_digit(10));
+
+        let negative = c == '-';
+        num.push(c);
+        // Parse leading digits
+        while self.read().is_digit(10) {
+            num.push(self.pop());
+        }
+        c = self.read();
+        if c == '.' {
+            if self.peek().is_digit(10) {
+                // Pushes .
+                num.push(self.pop());
+                return self.lex_float(num, false);
+            }
+            return to_integer_literal(&num, 10);
+        }
+        if c == 'e' || c == 'E' {
+            let c2 = self.peek();
+            if c2 == '-' || c2 == '+' {
+                num.push(self.pop());
+                num.push(self.pop());
+                return self.lex_float(num, true);
+            } else if c2.is_digit(10) {
+                num.push(self.pop());
+                return self.lex_float(num, true);
+            }
+        }
+        // If followed by '#', the leading digits were the radix
+        if c == '#' {
+            self.skip();
+            // Parse in the given radix
+            let radix = match num[1..].parse::<u32>() {
+                Ok(r) => r,
+                Err(e) => {
+                    return Token::Error(LexicalError::InvalidRadix {
+                        span: self.span(),
+                        reason: e.description().to_string(),
+                    });
+                }
+            };
+            if radix >= 2 && radix <= 32 {
+                c = self.read();
+                if c.is_digit(radix) {
+                    let mut num = String::new();
+                    if negative {
+                        num.push('-');
+                    }
+                    num.push(self.pop());
+                    while self.read().is_digit(radix) {
+                        num.push(self.pop());
+                    }
+                    return to_integer_literal(&num, radix);
+                } else {
+                    Token::Error(LexicalError::UnexpectedCharacter {
+                        start: self.span().start(),
+                        found: c,
+                    })
+                }
+            } else {
+                Token::Error(LexicalError::InvalidRadix {
+                    span: self.span(),
+                    reason: "invalid radix (must be in 2..32)".to_string(),
+                })
+            }
+        } else {
+            to_integer_literal(&num, 10)
+        }
+    }
+
+    // Called after consuming a number up to and including the '.'
+    #[inline]
+    fn lex_float(&mut self, num: String, seen_e: bool) -> Token {
+        let mut num = num;
+        let mut c = self.pop();
+        debug_assert!(c.is_digit(10));
+
+        num.push(c);
+
+        while self.read().is_digit(10) {
+            num.push(self.pop());
+        }
+
+        c = self.read();
+
+        // If we've already seen e|E, then we're done
+        if seen_e {
+            return self.to_float_literal(num);
+        }
+
+        if c == 'E' || c == 'e' {
+            num.push(self.pop());
+            c = self.read();
+            if c == '-' || c == '+' {
+                num.push(self.pop());
+                c = self.read();
+            }
+            if c.is_digit(10) {
+                while self.read().is_digit(10) {
+                    num.push(self.pop());
+                }
+
+                return self.to_float_literal(num);
+            }
+            return Token::Error(LexicalError::InvalidFloat {
+                span: self.span(),
+                reason: "expected digits after scientific notation".to_string(),
+            });
+        }
+        self.to_float_literal(num)
+    }
+
+    fn to_float_literal(&self, num: String) -> Token {
+        match f64::from_str(&num) {
+            Ok(f) => Token::Float(f),
+            Err(e) => Token::Error(LexicalError::InvalidFloat {
+                span: self.span(),
+                reason: e.description().to_string(),
+            }),
+        }
+    }
+}
+
+impl<S> Iterator for Lexer<S>
+where
+    S: Source,
+{
+    type Item = Lexed;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.lex()
+    }
+}
+
+// Converts the string literal into either a `i64` or arbitrary precision integer, preferring `i64`.
+//
+// This function panics if the literal is unparseable due to being invalid for the given radix,
+// or containing non-ASCII digits.
+fn to_integer_literal(literal: &str, radix: u32) -> Token {
+    if let Ok(i) = i64::from_str_radix(literal, radix) {
+        return Token::Integer(i);
+    }
+    let bi = Integer::from_str_radix(literal, radix as i32).unwrap();
+    Token::BigInteger(bi)
+}
+
+#[cfg(test)]
+mod test {
+    use std::borrow::Cow;
+    use std::sync::Arc;
+
+    use diagnostics::{ByteIndex, ByteSpan, FileMap, FileName};
+    use pretty_assertions::assert_eq;
+
+    use crate::lexer::*;
+
+    macro_rules! symbol {
+        ($sym:expr) => {
+            Symbol::intern($sym)
+        };
+    }
+
+    macro_rules! assert_lex(
+        ($input:expr, $expected:expr) => ({
+            let filemap = FileMap::new(FileName::Virtual(Cow::Borrowed("nofile")), $input);
+            let source = FileMapSource::new(Arc::new(filemap));
+            let scanner = Scanner::new(source);
+            let lexer = Lexer::new(scanner);
+            let results = lexer.map(|result| {
+                match result {
+                    Ok(LexicalToken(start, token, end)) => {
+                        Ok((start.to_usize(), token, end.to_usize()))
+                    }
+                    Err(err) =>  {
+                        Err(err)
+                    }
+                }
+            }).collect::<Vec<_>>();
+            assert_eq!(results, $expected);
+        })
+    );
+
+    #[test]
+    fn lex_symbols() {
+        assert_lex!(":", vec![Ok((1, Token::Colon, 2))]);
+        assert_lex!(",", vec![Ok((1, Token::Comma, 2))]);
+        assert_lex!("=", vec![Ok((1, Token::Equals, 2))]);
+    }
+
+    #[test]
+    fn lex_comment() {
+        assert_lex!("% this is a comment", vec![Ok((1, Token::Comment, 20))]);
+        assert_lex!("% @author Paul", vec![Ok((1, Token::Edoc, 15))]);
+    }
+
+    #[test]
+    fn lex_float_literal() {
+        // With leading 0
+        assert_lex!("0.0", vec![Ok((1, Token::Float(0.0), 4))]);
+        assert_lex!("000051.0", vec![Ok((1, Token::Float(51.0), 9))]);
+        assert_lex!("05162.0", vec![Ok((1, Token::Float(5162.0), 8))]);
+        assert_lex!("099.0", vec![Ok((1, Token::Float(99.0), 6))]);
+        assert_lex!("04624.51235", vec![Ok((1, Token::Float(4624.51235), 12))]);
+        assert_lex!("0.987", vec![Ok((1, Token::Float(0.987), 6))]);
+        assert_lex!("0.55e10", vec![Ok((1, Token::Float(0.55e10), 8))]);
+        assert_lex!("612.0e61", vec![Ok((1, Token::Float(612e61), 9))]);
+        assert_lex!("0.0e-1", vec![Ok((1, Token::Float(0e-1), 7))]);
+        assert_lex!("41.0e+9", vec![Ok((1, Token::Float(41e+9), 8))]);
+
+        // Without leading 0
+        assert_lex!("5162.0", vec![Ok((1, Token::Float(5162.0), 7))]);
+        assert_lex!("99.0", vec![Ok((1, Token::Float(99.0), 5))]);
+        assert_lex!("4624.51235", vec![Ok((1, Token::Float(4624.51235), 11))]);
+        assert_lex!("612.0e61", vec![Ok((1, Token::Float(612e61), 9))]);
+        assert_lex!("41.0e+9", vec![Ok((1, Token::Float(41e+9), 8))]);
+
+        // With leading negative sign
+        assert_lex!("-700.5", vec![Ok((1, Token::Float(-700.5), 7))]);
+        assert_lex!("-9.0e2", vec![Ok((1, Token::Float(-9.0e2), 7))]);
+        assert_lex!("-0.5e1", vec![Ok((1, Token::Float(-0.5e1), 7))]);
+        assert_lex!("-0.0", vec![Ok((1, Token::Float(-0.0), 5))]);
+    }
+
+    #[test]
+    fn lex_identifier_or_atom() {
+        assert_lex!(
+            "_identifier",
+            vec![Ok((1, Token::Ident(symbol!("_identifier")), 12))]
+        );
+        assert_lex!(
+            "_Identifier",
+            vec![Ok((1, Token::Ident(symbol!("_Identifier")), 12))]
+        );
+        assert_lex!(
+            "identifier",
+            vec![Ok((1, Token::Atom(symbol!("identifier")), 11))]
+        );
+        assert_lex!(
+            "Identifier",
+            vec![Ok((1, Token::Ident(symbol!("Identifier")), 11))]
+        );
+        assert_lex!("z0123", vec![Ok((1, Token::Atom(symbol!("z0123")), 6))]);
+        assert_lex!(
+            "i_d@e_t0123",
+            vec![Ok((1, Token::Atom(symbol!("i_d@e_t0123")), 12))]
+        );
+    }
+
+    #[test]
+    fn lex_integer_literal() {
+        // Decimal
+        assert_lex!("1", vec![Ok((1, Token::Integer(1), 2))]);
+        assert_lex!("9624", vec![Ok((1, Token::Integer(9624), 5))]);
+        assert_lex!("-1", vec![Ok((1, Token::Integer(-1), 3))]);
+        assert_lex!("-9624", vec![Ok((1, Token::Integer(-9624), 6))]);
+
+        // Hexadecimal
+        assert_lex!(r#"\x00"#, vec![Ok((1, Token::Integer(0x0), 5))]);
+        assert_lex!(r#"\x{1234FF}"#, vec![Ok((1, Token::Integer(0x1234FF), 11))]);
+        assert_lex!("-16#0", vec![Ok((1, Token::Integer(0x0), 6))]);
+        assert_lex!("-16#1234FF", vec![Ok((1, Token::Integer(-0x1234FF), 11))]);
+
+        // Octal
+        assert_lex!(r#"\00"#, vec![Ok((1, Token::Integer(0), 4))]);
+        assert_lex!(r#"\0624"#, vec![Ok((1, Token::Integer(0o624), 6))]);
+
+        // Octal integer literal followed by non-octal digits.
+        assert_lex!(
+            r#"\008"#,
+            vec![Ok((1, Token::Integer(0), 4)), Ok((4, Token::Integer(8), 5))]
+        );
+        assert_lex!(
+            r#"\01238"#,
+            vec![
+                Ok((1, Token::Integer(0o123), 6)),
+                Ok((6, Token::Integer(8), 7))
+            ]
+        );
+    }
+
+    #[test]
+    fn lex_string() {
+        assert_lex!(
+            r#""this is a string""#,
+            vec![Ok((1, Token::String(symbol!("this is a string")), 19,))]
+        );
+
+        assert_lex!(
+            r#""this is a string"#,
+            vec![Err(LexicalError::UnclosedString {
+                span: ByteSpan::new(ByteIndex(1), ByteIndex(18))
+            })]
+        );
+    }
+
+    #[test]
+    fn lex_whitespace() {
+        assert_lex!("      \n \t", vec![]);
+        assert_lex!("\r\n", vec![]);
+    }
+}

--- a/frontend/src/lexer/scanner.rs
+++ b/frontend/src/lexer/scanner.rs
@@ -1,0 +1,74 @@
+use diagnostics::{ByteIndex, ByteSpan};
+
+use super::source::Source;
+
+/// An implementation of `Scanner` for general use
+pub struct Scanner<S> {
+    source: S,
+    current: (ByteIndex, char),
+    pending: (ByteIndex, char),
+    start: ByteIndex,
+    end: ByteIndex,
+}
+impl<S> Scanner<S>
+where
+    S: Source,
+{
+    pub fn new(mut source: S) -> Self {
+        let span = source.span();
+        let start = span.start();
+        let end = span.end();
+        let current = source.read().unwrap_or((ByteIndex(0), '\0'));
+        let pending = source.read().unwrap_or((ByteIndex(0), '\0'));
+        Scanner {
+            source,
+            current,
+            pending,
+            start,
+            end,
+        }
+    }
+
+    pub fn start(&self) -> ByteIndex {
+        self.start
+    }
+
+    #[inline]
+    pub fn advance(&mut self) {
+        self.current = self.pending;
+        self.pending = match self.source.read() {
+            None => (self.end, '\0'),
+            Some(ic) => ic,
+        };
+    }
+
+    #[inline]
+    pub fn pop(&mut self) -> (ByteIndex, char) {
+        let current = self.current;
+        self.advance();
+        current
+    }
+
+    #[inline]
+    pub fn peek(&self) -> (ByteIndex, char) {
+        self.pending
+    }
+
+    #[inline]
+    pub fn peek_next(&mut self) -> (ByteIndex, char) {
+        match self.source.peek() {
+            None => (self.end, '\0'),
+            Some((pos, c)) => (pos, c),
+        }
+    }
+
+    #[inline]
+    pub fn read(&self) -> (ByteIndex, char) {
+        self.current
+    }
+
+    #[inline]
+    pub fn slice(&self, span: ByteSpan) -> &str {
+        self.source.slice(span)
+    }
+}

--- a/frontend/src/lexer/source.rs
+++ b/frontend/src/lexer/source.rs
@@ -1,0 +1,279 @@
+use std::char;
+use std::env;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use failure::Fail;
+
+use crate::util;
+use diagnostics::{ByteIndex, ByteOffset, ByteSpan, CodeMap, Diagnostic, FileMap, FileName};
+
+pub type SourceResult<T> = std::result::Result<T, SourceError>;
+
+pub trait Source: Sized {
+    fn from_path<P: AsRef<Path>>(codemap: Arc<Mutex<CodeMap>>, path: P) -> SourceResult<Self>;
+
+    fn read(&mut self) -> Option<(ByteIndex, char)>;
+
+    fn peek(&mut self) -> Option<(ByteIndex, char)>;
+
+    fn span(&self) -> ByteSpan;
+
+    fn slice(&self, span: ByteSpan) -> &str;
+}
+
+#[derive(Fail, Debug)]
+pub enum SourceError {
+    #[fail(display = "{}", _0)]
+    IO(std::io::Error),
+
+    #[fail(display = "invalid source path")]
+    InvalidPath(String),
+
+    #[fail(display = "invalid environment variable '{}'", _1)]
+    InvalidEnvironmentVariable(std::env::VarError, String),
+}
+impl std::convert::From<std::io::Error> for SourceError {
+    fn from(err: std::io::Error) -> SourceError {
+        SourceError::IO(err)
+    }
+}
+impl SourceError {
+    pub fn to_diagnostic(&self) -> Diagnostic {
+        match self {
+            SourceError::IO(ref err) => Diagnostic::new_error(err.to_string()),
+            SourceError::InvalidPath(ref reason) => {
+                Diagnostic::new_error(format!("invalid path: {}", reason))
+            }
+            SourceError::InvalidEnvironmentVariable(env::VarError::NotPresent, ref var) => {
+                Diagnostic::new_error(format!(
+                    "invalid environment variable '{}': not defined",
+                    var
+                ))
+            }
+            SourceError::InvalidEnvironmentVariable(_, ref var) => Diagnostic::new_error(format!(
+                "invalid environment variable '{}': contains invalid unicode data",
+                var
+            )),
+        }
+    }
+}
+
+/// A source which reads from a `diagnostics::FileMap`
+pub struct FileMapSource {
+    src: Arc<FileMap>,
+    bytes: *const [u8],
+    start: ByteIndex,
+    peek: Option<(ByteIndex, char)>,
+    end: usize,
+    pos: usize,
+    eof: bool,
+}
+impl FileMapSource {
+    pub fn new(src: Arc<FileMap>) -> Self {
+        let start = src.span().start();
+        let end = src.src.len();
+        let bytes: *const [u8] = src.src.as_bytes();
+        let mut source = FileMapSource {
+            src,
+            bytes,
+            peek: None,
+            start,
+            end,
+            pos: 0,
+            eof: false,
+        };
+        source.peek = unsafe { source.next_char_internal() };
+        source
+    }
+
+    fn peek_char(&self) -> Option<(ByteIndex, char)> {
+        self.peek
+    }
+
+    fn next_char(&mut self) -> Option<(ByteIndex, char)> {
+        // If we've peeked a char already, return that
+        let result = if self.peek.is_some() {
+            std::mem::replace(&mut self.peek, None)
+        } else {
+            let next = unsafe { self.next_char_internal() };
+            match next {
+                None => {
+                    self.eof = true;
+                    return None;
+                }
+                result => result,
+            }
+        };
+
+        // Reset peek
+        self.peek = unsafe { self.next_char_internal() };
+
+        result
+    }
+
+    #[inline]
+    unsafe fn next_char_internal(&mut self) -> Option<(ByteIndex, char)> {
+        let mut pos = self.pos;
+        let end = self.end;
+        if pos == end {
+            self.eof = true;
+        }
+
+        if self.eof {
+            return None;
+        }
+
+        let start = self.start + ByteOffset(pos as i64);
+
+        let bytes: &[u8] = &*self.bytes;
+
+        // Decode UTF-8
+        let x = *bytes.get_unchecked(pos);
+        if x < 128 {
+            self.pos = pos + 1;
+            return Some((start, char::from_u32_unchecked(x as u32)));
+        }
+
+        // Multibyte case follows
+        // Decode from a byte combination out of: [[[x y] z] w]
+        // NOTE: Performance is sensitive to the exact formulation here
+        let init = Self::utf8_first_byte(x, 2);
+
+        pos = pos + 1;
+        let y = if pos == end {
+            0u8
+        } else {
+            *bytes.get_unchecked(pos)
+        };
+        let mut ch = Self::utf8_acc_cont_byte(init, y);
+        if x >= 0xE0 {
+            // [[x y z] w] case
+            // 5th bit in 0xE0 .. 0xEF is always clear, so `init` is still valid
+            pos = pos + 1;
+            let z = if pos == end {
+                0u8
+            } else {
+                *bytes.get_unchecked(pos)
+            };
+            let y_z = Self::utf8_acc_cont_byte((y & Self::CONT_MASK) as u32, z);
+            ch = init << 12 | y_z;
+            if x >= 0xF0 {
+                // [x y z w] case
+                // use only the lower 3 bits of `init`
+                pos = pos + 1;
+                let w = if pos == end {
+                    0u8
+                } else {
+                    *bytes.get_unchecked(pos)
+                };
+                ch = (init & 7) << 18 | Self::utf8_acc_cont_byte(y_z, w);
+            }
+        }
+
+        pos = pos + 1;
+        if pos >= end {
+            self.eof = true
+        }
+        self.pos = pos;
+
+        Some((start, char::from_u32_unchecked(ch as u32)))
+    }
+
+    /// Returns the initial codepoint accumulator for the first byte.
+    /// The first byte is special, only want bottom 5 bits for width 2, 4 bits
+    /// for width 3, and 3 bits for width 4.
+    #[inline]
+    fn utf8_first_byte(byte: u8, width: u32) -> u32 {
+        (byte & (0x7F >> width)) as u32
+    }
+
+    /// Returns the value of `ch` updated with continuation byte `byte`.
+    #[inline]
+    fn utf8_acc_cont_byte(ch: u32, byte: u8) -> u32 {
+        (ch << 6) | (byte & Self::CONT_MASK) as u32
+    }
+
+    /// Mask of the value bits of a continuation byte.
+    const CONT_MASK: u8 = 0b0011_1111;
+}
+impl Source for FileMapSource {
+    fn from_path<P: AsRef<Path>>(codemap: Arc<Mutex<CodeMap>>, path: P) -> SourceResult<Self> {
+        let path = util::substitute_path_variables(path)?;
+        let filemap = {
+            codemap
+                .lock()
+                .unwrap()
+                .add_filemap_from_disk(FileName::real(path))?
+        };
+        Ok(FileMapSource::new(filemap))
+    }
+
+    #[inline]
+    fn read(&mut self) -> Option<(ByteIndex, char)> {
+        self.next_char()
+    }
+
+    #[inline]
+    fn peek(&mut self) -> Option<(ByteIndex, char)> {
+        self.peek_char()
+    }
+
+    #[inline]
+    fn span(&self) -> ByteSpan {
+        ByteSpan::new(self.start.clone(), self.start + ByteOffset(self.end as i64))
+    }
+
+    #[inline]
+    fn slice(&self, span: ByteSpan) -> &str {
+        self.src.src_slice(span).unwrap()
+    }
+}
+
+impl Iterator for FileMapSource {
+    type Item = (ByteIndex, char);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.read()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::borrow::Cow;
+    use std::sync::Arc;
+
+    use diagnostics::{ByteIndex, FileMap, FileName};
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    fn make_source(input: &str) -> FileMapSource {
+        let filemap = FileMap::new(FileName::Virtual(Cow::Borrowed("nofile")), input);
+        FileMapSource::new(Arc::new(filemap))
+    }
+
+    fn read_all_chars(input: &str) -> Vec<char> {
+        let source = make_source(input);
+        source.map(|result| result.1).collect()
+    }
+
+    #[test]
+    fn file_source() {
+        let expected = vec!['h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd', '!'];
+
+        let chars = read_all_chars("hello world!");
+
+        assert_eq!(expected, chars);
+
+        let mut source = make_source("hello world!");
+        assert_eq!(Some((ByteIndex(1), 'h')), source.peek());
+        assert_eq!(Some((ByteIndex(1), 'h')), source.next());
+
+        let mut source = make_source("éé");
+        assert_eq!(Some((ByteIndex(1), 'é')), source.peek());
+        assert_eq!(Some((ByteIndex(1), 'é')), source.next());
+        assert_eq!(Some((ByteIndex(3), 'é')), source.peek());
+        assert_eq!(Some((ByteIndex(3), 'é')), source.next());
+    }
+}

--- a/frontend/src/lexer/symbol.rs
+++ b/frontend/src/lexer/symbol.rs
@@ -1,0 +1,690 @@
+//! An "interner" is a data structure that associates values with usize tags and
+//! allows bidirectional lookup; i.e., given a value, one can easily find the
+//! type, and vice versa.
+#![allow(unused)]
+use std::cell::RefCell;
+use std::cmp::{Ord, Ordering, PartialEq, PartialOrd};
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::str;
+use std::sync::{Arc, RwLock};
+
+use lazy_static::lazy_static;
+use rustc_hash::FxHashMap;
+
+use crate::arena::DroplessArena;
+
+use diagnostics::{ByteSpan, DUMMY_SPAN};
+
+lazy_static! {
+    /// A globally accessible symbol table
+    pub static ref SYMBOL_TABLE: SymbolTable = {
+        SymbolTable::new()
+    };
+}
+
+pub struct SymbolTable {
+    interner: RwLock<Interner>,
+}
+impl SymbolTable {
+    pub fn new() -> Self {
+        SymbolTable {
+            interner: RwLock::new(Interner::fresh()),
+        }
+    }
+}
+unsafe impl Sync for SymbolTable {}
+
+#[derive(Copy, Clone, Eq)]
+pub struct Ident {
+    pub name: Symbol,
+    pub span: ByteSpan,
+}
+
+impl Ident {
+    #[inline]
+    pub const fn new(name: Symbol, span: ByteSpan) -> Ident {
+        Ident { name, span }
+    }
+
+    #[inline]
+    pub const fn with_empty_span(name: Symbol) -> Ident {
+        Ident::new(name, DUMMY_SPAN)
+    }
+
+    /// Maps an interned string to an identifier with an empty syntax context.
+    pub fn from_interned_str(string: InternedString) -> Ident {
+        Ident::with_empty_span(string.as_symbol())
+    }
+
+    /// Maps a string to an identifier with an empty syntax context.
+    pub fn from_str(string: &str) -> Ident {
+        Ident::with_empty_span(Symbol::intern(string))
+    }
+
+    pub fn unquote_string(self) -> Ident {
+        Ident::new(Symbol::intern(self.as_str().trim_matches('"')), self.span)
+    }
+
+    pub fn unquote_atom(self) -> Ident {
+        Ident::new(Symbol::intern(self.as_str().trim_matches('\'')), self.span)
+    }
+
+    pub fn gensym(self) -> Ident {
+        Ident::new(self.name.gensymed(), self.span)
+    }
+
+    pub fn as_str(self) -> LocalInternedString {
+        self.name.as_str()
+    }
+
+    pub fn as_interned_str(self) -> InternedString {
+        self.name.as_interned_str()
+    }
+}
+
+impl PartialOrd for Ident {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.name.partial_cmp(&other.name)
+    }
+}
+
+impl PartialEq for Ident {
+    fn eq(&self, rhs: &Self) -> bool {
+        self.name == rhs.name
+    }
+}
+
+impl Hash for Ident {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+    }
+}
+
+impl fmt::Debug for Ident {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Ident<{} {:?}>", self.name, self.span)
+    }
+}
+
+impl fmt::Display for Ident {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.name, f)
+    }
+}
+
+#[derive(Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SymbolIndex(u32);
+impl Clone for SymbolIndex {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl From<SymbolIndex> for u32 {
+    #[inline]
+    fn from(v: SymbolIndex) -> u32 {
+        v.as_u32()
+    }
+}
+impl From<SymbolIndex> for usize {
+    #[inline]
+    fn from(v: SymbolIndex) -> usize {
+        v.as_usize()
+    }
+}
+impl SymbolIndex {
+    // shave off 256 indices at the end to allow space for packing these indices into enums
+    pub const MAX_AS_U32: u32 = 0xFFFF_FF00;
+
+    pub const MAX: SymbolIndex = SymbolIndex::new(0xFFFF_FF00);
+
+    #[inline]
+    const fn new(n: u32) -> Self {
+        // This will fail at const eval time unless `value <=
+        // max` is true (in which case we get the index 0).
+        // It will also fail at runtime, of course, but in a
+        // kind of wacky way.
+        let _ = ["out of range value used"][!(n <= Self::MAX_AS_U32) as usize];
+
+        SymbolIndex(n)
+    }
+
+    #[inline]
+    pub fn as_u32(self) -> u32 {
+        self.0
+    }
+
+    #[inline]
+    pub fn as_usize(self) -> usize {
+        self.0 as usize
+    }
+}
+
+/// A symbol is an interned or gensymed string.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Symbol(SymbolIndex);
+
+impl Symbol {
+    const fn new(n: u32) -> Self {
+        Symbol(SymbolIndex::new(n))
+    }
+
+    /// Maps a string to its interned representation.
+    pub fn intern(string: &str) -> Self {
+        with_interner(|interner| interner.intern(string))
+    }
+
+    pub fn interned(self) -> Self {
+        with_interner(|interner| interner.interned(self))
+    }
+
+    /// Gensyms a new usize, using the current interner.
+    pub fn gensym(string: &str) -> Self {
+        with_interner(|interner| interner.gensym(string))
+    }
+
+    pub fn gensymed(self) -> Self {
+        with_interner(|interner| interner.gensymed(self))
+    }
+
+    pub fn as_str(self) -> LocalInternedString {
+        with_interner(|interner| unsafe {
+            LocalInternedString {
+                string: ::std::mem::transmute::<&str, &str>(interner.get(self)),
+            }
+        })
+    }
+
+    pub fn as_interned_str(self) -> InternedString {
+        with_interner(|interner| InternedString {
+            symbol: interner.interned(self),
+        })
+    }
+
+    #[inline]
+    pub fn as_u32(self) -> u32 {
+        self.0.as_u32()
+    }
+
+    #[inline]
+    pub fn as_usize(self) -> usize {
+        self.0.as_usize()
+    }
+}
+
+impl fmt::Debug for Symbol {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let is_gensymed = with_interner(|interner| interner.is_gensymed(*self));
+        if is_gensymed {
+            write!(f, "{}({:?})", self, self.0)
+        } else {
+            write!(f, "{}({:?})", self, self.0)
+        }
+    }
+}
+
+impl fmt::Display for Symbol {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.as_str(), f)
+    }
+}
+
+impl<T: ::std::ops::Deref<Target = str>> PartialEq<T> for Symbol {
+    fn eq(&self, other: &T) -> bool {
+        self.as_str() == other.deref()
+    }
+}
+
+// The `&'static str`s in this type actually point into the arena.
+//
+// Note that normal symbols are indexed upward from 0, and gensyms are indexed
+// downward from SymbolIndex::MAX_AS_U32.
+#[derive(Default)]
+pub struct Interner {
+    arena: DroplessArena,
+    pub names: FxHashMap<&'static str, Symbol>,
+    pub strings: Vec<&'static str>,
+    gensyms: Vec<Symbol>,
+}
+
+impl Interner {
+    fn prefill(init: &[&str]) -> Self {
+        let mut this = Interner::default();
+        for &string in init {
+            if string == "" {
+                // We can't allocate empty strings in the arena, so handle this here.
+                let name = Symbol::new(this.strings.len() as u32);
+                this.names.insert("", name);
+                this.strings.push("");
+            } else {
+                this.intern(string);
+            }
+        }
+        this
+    }
+
+    pub fn intern(&mut self, string: &str) -> Symbol {
+        if let Some(&name) = self.names.get(string) {
+            return name;
+        }
+
+        let name = Symbol::new(self.strings.len() as u32);
+
+        // `from_utf8_unchecked` is safe since we just allocated a `&str` which is known to be
+        // UTF-8.
+        let string: &str =
+            unsafe { str::from_utf8_unchecked(self.arena.alloc_slice(string.as_bytes())) };
+        // It is safe to extend the arena allocation to `'static` because we only access
+        // these while the arena is still alive.
+        let string: &'static str = unsafe { &*(string as *const str) };
+        self.strings.push(string);
+        self.names.insert(string, name);
+        name
+    }
+
+    pub fn interned(&self, symbol: Symbol) -> Symbol {
+        if (symbol.0.as_usize()) < self.strings.len() {
+            symbol
+        } else {
+            self.interned(self.gensyms[(SymbolIndex::MAX_AS_U32 - symbol.0.as_u32()) as usize])
+        }
+    }
+
+    fn gensym(&mut self, string: &str) -> Symbol {
+        let symbol = self.intern(string);
+        self.gensymed(symbol)
+    }
+
+    fn gensymed(&mut self, symbol: Symbol) -> Symbol {
+        self.gensyms.push(symbol);
+        Symbol::new(SymbolIndex::MAX_AS_U32 - self.gensyms.len() as u32 + 1)
+    }
+
+    fn is_gensymed(&mut self, symbol: Symbol) -> bool {
+        symbol.0.as_usize() >= self.strings.len()
+    }
+
+    pub fn get(&self, symbol: Symbol) -> &str {
+        match self.strings.get(symbol.0.as_usize()) {
+            Some(string) => string,
+            None => self.get(self.gensyms[(SymbolIndex::MAX_AS_U32 - symbol.0.as_u32()) as usize]),
+        }
+    }
+}
+
+// In this macro, there is the requirement that the name (the number) must be monotonically
+// increasing by one in the special identifiers, starting at 0; the same holds for the keywords,
+// except starting from the next number instead of zero.
+macro_rules! declare_atoms {(
+    $( ($index: expr, $konst: ident, $string: expr) )*
+) => {
+    pub mod symbols {
+        use super::Symbol;
+        $(
+            #[allow(non_upper_case_globals)]
+            pub const $konst: Symbol = super::Symbol::new($index);
+        )*
+
+        /// Used *only* for testing that the declared atoms have no gaps
+        /// NOTE: The length must be static, so it must be changed when new
+        /// declared keywords are added to the list
+        pub(super) static DECLARED: [(Symbol, &'static str); 55] = [$(($konst, $string),)*];
+    }
+
+    impl Interner {
+        pub fn fresh() -> Self {
+            let interner = Interner::prefill(&[$($string,)*]);
+            interner
+        }
+    }
+}}
+
+// NOTE: When determining whether an Ident is a keyword or not, we compare against
+// the ident table index, but if a hole is left in the table, then non-keyword idents
+// will be interned with an id in the keyword range. It is important to ensure there are
+// no holes, which means you have to adjust the indexes when adding a new keyword earlier
+// in the table
+declare_atoms! {
+    // Special reserved identifiers used internally, such as for error recovery
+    (0,  Invalid,      "")
+    // Keywords that are used in Erlang
+    (1,  After,        "after")
+    (2,  Begin,        "begin")
+    (3,  Case,         "case")
+    (4,  Try,          "try")
+    (5,  Catch,        "catch")
+    (6,  End,          "end")
+    (7,  Fun,          "fun")
+    (8,  If,           "if")
+    (9,  Of,           "of")
+    (10, Receive,      "receive")
+    (11, When,         "when")
+    (12, AndAlso,      "andalso")
+    (13, OrElse,       "orelse")
+    (14, Bnot,         "bnot")
+    (15, Not,          "not")
+    (16, Div,          "div")
+    (17, Rem,          "rem")
+    (18, Band,         "band")
+    (19, And,          "and")
+    (20, Bor,          "bor")
+    (21, Bxor,         "bxor")
+    (22, Bsl,          "bsl")
+    (23, Bsr,          "bsr")
+    (24, Or,           "or")
+    (25, Xor,          "xor")
+    // Not reserved words, but used in attributes or preprocessor directives
+    (26, Module,       "module")
+    (27, Export,       "export")
+    (28, Import,       "import")
+    (29, Compile,      "compile")
+    (30, Vsn,          "vsn")
+    (31, OnLoad,       "on_load")
+    (32, Behaviour,    "behaviour")
+    (33, Spec,         "spec")
+    (34, Callback,     "callback")
+    (35, Include,      "include")
+    (36, IncludeLib,   "include_lib")
+    (37, Define,       "define")
+    (38, Undef,        "undef")
+    (39, Ifdef,        "ifdef")
+    (40, Ifndef,       "ifndef")
+    (41, Else,         "else")
+    (42, Elif,         "elif")
+    (43, Endif,        "endif")
+    (44, Error,        "error")
+    (45, Warning,      "warning")
+    // Common words
+    (46, True,         "true")
+    (47, False,        "false")
+    (48, ModuleInfo,   "module_info")
+    (49, RecordInfo,   "record_info")
+    (50, BehaviourInfo,"behaviour_info")
+    (51, Exports,      "exports")
+    (52, Attributes,   "attributes")
+    (53, Native,       "native")
+    (54, Deprecated,   "deprecated")
+}
+
+impl Symbol {
+    /// Returns `true` if the token is a keyword, reserved in all name positions
+    pub fn is_keyword(self) -> bool {
+        self > symbols::Invalid && self <= symbols::Xor
+    }
+
+    /// Returns `true` if the token is a reserved attribute name
+    pub fn is_reserved_attr(self) -> bool {
+        self >= symbols::Module && self <= symbols::Warning
+    }
+
+    /// Returns `true` if the token is a preprocessor directive name
+    pub fn is_preprocessor_directive(self) -> bool {
+        self >= symbols::Include && self <= symbols::Warning
+    }
+}
+
+impl Ident {
+    pub fn is_keyword(self) -> bool {
+        self.name.is_keyword()
+    }
+
+    pub fn is_reserved_attr(self) -> bool {
+        self.name.is_reserved_attr()
+    }
+
+    pub fn is_preprocessor_directive(self) -> bool {
+        self.name.is_preprocessor_directive()
+    }
+}
+
+// If an interner exists, return it. Otherwise, prepare a fresh one.
+#[inline]
+fn with_interner<T, F: FnOnce(&mut Interner) -> T>(f: F) -> T {
+    let mut r = SYMBOL_TABLE
+        .interner
+        .write()
+        .expect("unable to acquire write lock for symbol table");
+    f(&mut *r)
+    //GLOBALS.with(|globals| {
+    //f(&mut *globals.symbol_interner.lock().expect("symbol interner lock was held"))
+    //})
+}
+
+#[inline]
+fn with_read_only_interner<T, F: FnOnce(&Interner) -> T>(f: F) -> T {
+    let r = SYMBOL_TABLE
+        .interner
+        .read()
+        .expect("unable to acquire read lock for symbol table");
+    f(&*r)
+}
+
+/// Represents a string stored in the interner. Because the interner outlives any thread
+/// which uses this type, we can safely treat `string` which points to interner data,
+/// as an immortal string, as long as this type never crosses between threads.
+#[derive(Clone, Copy, Hash, PartialOrd, Eq, Ord)]
+pub struct LocalInternedString {
+    string: &'static str,
+}
+
+impl LocalInternedString {
+    pub fn as_interned_str(self) -> InternedString {
+        InternedString {
+            symbol: Symbol::intern(self.string),
+        }
+    }
+
+    pub fn get(&self) -> &'static str {
+        self.string
+    }
+}
+
+impl<U: ?Sized> ::std::convert::AsRef<U> for LocalInternedString
+where
+    str: ::std::convert::AsRef<U>,
+{
+    fn as_ref(&self) -> &U {
+        self.string.as_ref()
+    }
+}
+
+impl<T: ::std::ops::Deref<Target = str>> ::std::cmp::PartialEq<T> for LocalInternedString {
+    fn eq(&self, other: &T) -> bool {
+        self.string == other.deref()
+    }
+}
+
+impl ::std::cmp::PartialEq<LocalInternedString> for str {
+    fn eq(&self, other: &LocalInternedString) -> bool {
+        self == other.string
+    }
+}
+
+impl<'a> ::std::cmp::PartialEq<LocalInternedString> for &'a str {
+    fn eq(&self, other: &LocalInternedString) -> bool {
+        *self == other.string
+    }
+}
+
+impl ::std::cmp::PartialEq<LocalInternedString> for String {
+    fn eq(&self, other: &LocalInternedString) -> bool {
+        self == other.string
+    }
+}
+
+impl<'a> ::std::cmp::PartialEq<LocalInternedString> for &'a String {
+    fn eq(&self, other: &LocalInternedString) -> bool {
+        *self == other.string
+    }
+}
+
+impl !Send for LocalInternedString {}
+impl !Sync for LocalInternedString {}
+
+impl ::std::ops::Deref for LocalInternedString {
+    type Target = str;
+    fn deref(&self) -> &str {
+        self.string
+    }
+}
+
+impl fmt::Debug for LocalInternedString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self.string, f)
+    }
+}
+
+impl fmt::Display for LocalInternedString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self.string, f)
+    }
+}
+
+/// Represents a string stored in the string interner.
+#[derive(Clone, Copy, Eq)]
+pub struct InternedString {
+    symbol: Symbol,
+}
+
+impl InternedString {
+    pub fn with<F: FnOnce(&str) -> R, R>(self, f: F) -> R {
+        let str = with_interner(|interner| interner.get(self.symbol) as *const str);
+        // This is safe because the interner keeps string alive until it is dropped.
+        // We can access it because we know the interner is still alive since we use a
+        // scoped thread local to access it, and it was alive at the beginning of this scope
+        unsafe { f(&*str) }
+    }
+
+    pub fn as_symbol(self) -> Symbol {
+        self.symbol
+    }
+
+    pub fn as_str(self) -> LocalInternedString {
+        self.symbol.as_str()
+    }
+}
+
+impl Hash for InternedString {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.with(|str| str.hash(state))
+    }
+}
+
+impl PartialOrd<InternedString> for InternedString {
+    fn partial_cmp(&self, other: &InternedString) -> Option<Ordering> {
+        if self.symbol == other.symbol {
+            return Some(Ordering::Equal);
+        }
+        self.with(|self_str| other.with(|other_str| self_str.partial_cmp(other_str)))
+    }
+}
+
+impl Ord for InternedString {
+    fn cmp(&self, other: &InternedString) -> Ordering {
+        if self.symbol == other.symbol {
+            return Ordering::Equal;
+        }
+        self.with(|self_str| other.with(|other_str| self_str.cmp(&other_str)))
+    }
+}
+
+impl<T: ::std::ops::Deref<Target = str>> PartialEq<T> for InternedString {
+    fn eq(&self, other: &T) -> bool {
+        self.with(|string| string == other.deref())
+    }
+}
+
+impl PartialEq<InternedString> for InternedString {
+    fn eq(&self, other: &InternedString) -> bool {
+        self.symbol == other.symbol
+    }
+}
+
+impl PartialEq<InternedString> for str {
+    fn eq(&self, other: &InternedString) -> bool {
+        other.with(|string| self == string)
+    }
+}
+
+impl<'a> PartialEq<InternedString> for &'a str {
+    fn eq(&self, other: &InternedString) -> bool {
+        other.with(|string| *self == string)
+    }
+}
+
+impl PartialEq<InternedString> for String {
+    fn eq(&self, other: &InternedString) -> bool {
+        other.with(|string| self == string)
+    }
+}
+
+impl<'a> PartialEq<InternedString> for &'a String {
+    fn eq(&self, other: &InternedString) -> bool {
+        other.with(|string| *self == string)
+    }
+}
+
+impl ::std::convert::From<InternedString> for String {
+    fn from(val: InternedString) -> String {
+        val.as_symbol().to_string()
+    }
+}
+
+impl fmt::Debug for InternedString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.with(|str| fmt::Debug::fmt(&str, f))
+    }
+}
+
+impl fmt::Display for InternedString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.with(|str| fmt::Display::fmt(&str, f))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interner_tests() {
+        let mut i: Interner = Interner::default();
+        // first one is zero:
+        assert_eq!(i.intern("dog"), Symbol::new(0));
+        // re-use gets the same entry:
+        assert_eq!(i.intern("dog"), Symbol::new(0));
+        // different string gets a different #:
+        assert_eq!(i.intern("cat"), Symbol::new(1));
+        assert_eq!(i.intern("cat"), Symbol::new(1));
+        // dog is still at zero
+        assert_eq!(i.intern("dog"), Symbol::new(0));
+        assert_eq!(i.gensym("zebra"), Symbol::new(SymbolIndex::MAX_AS_U32));
+        // gensym of same string gets new number:
+        assert_eq!(i.gensym("zebra"), Symbol::new(SymbolIndex::MAX_AS_U32 - 1));
+        // gensym of *existing* string gets new number:
+        assert_eq!(i.gensym("dog"), Symbol::new(SymbolIndex::MAX_AS_U32 - 2));
+    }
+
+    #[test]
+    fn interned_keywords_no_gaps() {
+        let mut i = Interner::fresh();
+        // Should already be interned with matching indexes
+        for (sym, s) in symbols::DECLARED.iter() {
+            assert_eq!(i.intern(&s), *sym)
+        }
+        // Should create a new symbol resulting in an index equal to the last entry in the table
+        assert_eq!(i.intern("foo").as_u32(), (i.names.len() - 1) as u32);
+    }
+
+    #[test]
+    fn unquote_string() {
+        let i = Ident::from_str("\"after\"");
+        assert_eq!(i.unquote_string().name, symbols::After);
+    }
+
+    #[test]
+    fn unquote_atom() {
+        let i = Ident::from_str("'after'");
+        assert_eq!(i.unquote_atom().name, symbols::After);
+    }
+}

--- a/frontend/src/lexer/token.rs
+++ b/frontend/src/lexer/token.rs
@@ -1,0 +1,536 @@
+use std::convert::TryFrom;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::mem;
+
+use rug::Integer;
+
+use diagnostics::{ByteIndex, ByteSpan};
+
+use super::{LexicalError, Symbol, TokenConvertError, TokenConvertResult};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LexicalToken(pub ByteIndex, pub Token, pub ByteIndex);
+impl LexicalToken {
+    #[inline]
+    pub fn token(&self) -> Token {
+        self.1.clone()
+    }
+
+    #[inline]
+    pub fn span(&self) -> ByteSpan {
+        ByteSpan::new(self.0, self.2)
+    }
+}
+impl fmt::Display for LexicalToken {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.token())
+    }
+}
+impl std::convert::Into<(ByteIndex, Token, ByteIndex)> for LexicalToken {
+    fn into(self) -> (ByteIndex, Token, ByteIndex) {
+        (self.0, self.1, self.2)
+    }
+}
+impl std::convert::From<(ByteIndex, Token, ByteIndex)> for LexicalToken {
+    fn from(triple: (ByteIndex, Token, ByteIndex)) -> LexicalToken {
+        LexicalToken(triple.0, triple.1, triple.2)
+    }
+}
+
+/// Used to identify the type of token expected in a TokenConvertError
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum TokenType {
+    Atom,
+    Ident,
+    String,
+    Symbol,
+}
+impl fmt::Display for TokenType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            TokenType::Atom => write!(f, "ATOM"),
+            TokenType::Ident => write!(f, "IDENT"),
+            TokenType::String => write!(f, "STRING"),
+            TokenType::Symbol => write!(f, "SYMBOL"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Hash)]
+pub struct AtomToken(pub ByteIndex, pub Token, pub ByteIndex);
+impl AtomToken {
+    pub fn token(&self) -> Token {
+        self.1.clone()
+    }
+    pub fn span(&self) -> ByteSpan {
+        ByteSpan::new(self.0, self.2)
+    }
+    pub fn symbol(&self) -> Symbol {
+        match self.token() {
+            Token::Atom(a) => a,
+            _ => unreachable!(),
+        }
+    }
+}
+impl TryFrom<LexicalToken> for AtomToken {
+    type Error = TokenConvertError;
+
+    fn try_from(t: LexicalToken) -> TokenConvertResult<AtomToken> {
+        use super::symbol::symbols;
+
+        match t {
+            LexicalToken(start, tok @ Token::Atom(_), end) => {
+                return Ok(AtomToken(start, tok, end))
+            }
+            LexicalToken(start, Token::If, end) => {
+                return Ok(AtomToken(start, Token::Atom(symbols::If), end));
+            }
+            t => Err(TokenConvertError {
+                span: t.span(),
+                token: t.token(),
+                expected: TokenType::Atom,
+            }),
+        }
+    }
+}
+impl Into<LexicalToken> for AtomToken {
+    fn into(self) -> LexicalToken {
+        LexicalToken(self.0, self.1, self.2)
+    }
+}
+impl fmt::Display for AtomToken {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.1.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Hash)]
+pub struct IdentToken(pub ByteIndex, pub Token, pub ByteIndex);
+impl IdentToken {
+    pub fn token(&self) -> Token {
+        self.1.clone()
+    }
+    pub fn span(&self) -> ByteSpan {
+        ByteSpan::new(self.0, self.2)
+    }
+    pub fn symbol(&self) -> Symbol {
+        match self.token() {
+            Token::Ident(a) => a,
+            _ => unreachable!(),
+        }
+    }
+}
+impl TryFrom<LexicalToken> for IdentToken {
+    type Error = TokenConvertError;
+
+    fn try_from(t: LexicalToken) -> TokenConvertResult<IdentToken> {
+        if let LexicalToken(start, tok @ Token::Ident(_), end) = t {
+            return Ok(IdentToken(start, tok, end));
+        }
+        Err(TokenConvertError {
+            span: t.span(),
+            token: t.token(),
+            expected: TokenType::Ident,
+        })
+    }
+}
+impl Into<LexicalToken> for IdentToken {
+    fn into(self) -> LexicalToken {
+        LexicalToken(self.0, self.1, self.2)
+    }
+}
+impl fmt::Display for IdentToken {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.1.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Hash)]
+pub struct StringToken(pub ByteIndex, pub Token, pub ByteIndex);
+impl StringToken {
+    pub fn token(&self) -> Token {
+        self.1.clone()
+    }
+    pub fn span(&self) -> ByteSpan {
+        ByteSpan::new(self.0, self.2)
+    }
+    pub fn symbol(&self) -> Symbol {
+        match self.token() {
+            Token::String(a) => a,
+            _ => unreachable!(),
+        }
+    }
+}
+impl TryFrom<LexicalToken> for StringToken {
+    type Error = TokenConvertError;
+
+    fn try_from(t: LexicalToken) -> TokenConvertResult<StringToken> {
+        if let LexicalToken(start, tok @ Token::String(_), end) = t {
+            return Ok(StringToken(start, tok, end));
+        }
+        Err(TokenConvertError {
+            span: t.span(),
+            token: t.token(),
+            expected: TokenType::String,
+        })
+    }
+}
+impl Into<LexicalToken> for StringToken {
+    fn into(self) -> LexicalToken {
+        LexicalToken(self.0, self.1, self.2)
+    }
+}
+impl fmt::Display for StringToken {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.1.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Hash)]
+pub struct SymbolToken(pub ByteIndex, pub Token, pub ByteIndex);
+impl SymbolToken {
+    pub fn token(&self) -> Token {
+        self.1.clone()
+    }
+    pub fn span(&self) -> ByteSpan {
+        ByteSpan::new(self.0, self.2)
+    }
+}
+impl TryFrom<LexicalToken> for SymbolToken {
+    type Error = TokenConvertError;
+
+    fn try_from(t: LexicalToken) -> TokenConvertResult<SymbolToken> {
+        match t {
+            LexicalToken(_, Token::Atom(_), _) => (),
+            LexicalToken(_, Token::Ident(_), _) => (),
+            LexicalToken(_, Token::String(_), _) => (),
+            LexicalToken(start, token, end) => return Ok(SymbolToken(start, token, end)),
+        }
+        Err(TokenConvertError {
+            span: t.span(),
+            token: t.token(),
+            expected: TokenType::Symbol,
+        })
+    }
+}
+impl Into<LexicalToken> for SymbolToken {
+    fn into(self) -> LexicalToken {
+        LexicalToken(self.0, self.1, self.2)
+    }
+}
+impl fmt::Display for SymbolToken {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.1.fmt(f)
+    }
+}
+
+/// This enum contains tokens produced by the lexer
+#[derive(Debug, Clone)]
+pub enum Token {
+    // Signifies end of input
+    EOF,
+    // A tokenization error which may be recovered from
+    Error(LexicalError),
+    // Docs
+    Comment,
+    Edoc,
+    // Literals
+    Char(char),
+    Integer(i64),
+    BigInteger(Integer),
+    Float(f64),
+    Atom(Symbol),
+    String(Symbol),
+    Ident(Symbol),
+    // Keywords and Symbols
+    LParen,
+    RParen,
+    Comma,
+    RightStab,
+    LBrace,
+    RBrace,
+    LBracket,
+    RBracket,
+    Bar,
+    BarBar,
+    LeftStab,
+    Semicolon,
+    Colon,
+    Pound,
+    Dot,
+    // Keywords
+    After,
+    Begin,
+    Case,
+    Try,
+    Catch,
+    End,
+    Fun,
+    If,
+    Of,
+    Receive,
+    When,
+    // Attributes
+    Record,
+    Spec,
+    Callback,
+    OptionalCallback,
+    Import,
+    Export,
+    ExportType,
+    Module,
+    Compile,
+    Vsn,
+    OnLoad,
+    Behaviour,
+    Deprecated,
+    Type,
+    Opaque,
+    // Operators
+    AndAlso,
+    OrElse,
+    Bnot,
+    Not,
+    Star,
+    Slash,
+    Div,
+    Rem,
+    Band,
+    And,
+    Plus,
+    Minus,
+    Bor,
+    Bxor,
+    Bsl,
+    Bsr,
+    Or,
+    Xor,
+    PlusPlus,
+    MinusMinus,
+    // ==
+    IsEqual,
+    // /=
+    IsNotEqual,
+    // =<
+    IsLessThanOrEqual,
+    // <
+    IsLessThan,
+    // >=
+    IsGreaterThanOrEqual,
+    // >
+    IsGreaterThan,
+    // =:=
+    IsExactlyEqual,
+    // =/=
+    IsExactlyNotEqual,
+    // <=
+    LeftArrow,
+    // =>
+    RightArrow,
+    // :=
+    ColonEqual,
+    // <<
+    BinaryStart,
+    // >>
+    BinaryEnd,
+    Bang,
+    // =
+    Equals,
+    ColonColon,
+    DotDot,
+    DotDotDot,
+    Question,
+    DoubleQuestion,
+}
+impl PartialEq for Token {
+    fn eq(&self, other: &Token) -> bool {
+        match *self {
+            Token::Char(c) => {
+                if let Token::Char(c2) = other {
+                    return c == *c2;
+                }
+            }
+            Token::Integer(i) => {
+                if let Token::Integer(i2) = other {
+                    return i == *i2;
+                }
+            }
+            Token::Float(n) => {
+                if let Token::Float(n2) = other {
+                    return n == *n2;
+                }
+            }
+            Token::Error(_) => {
+                if let Token::Error(_) = other {
+                    return true;
+                }
+            }
+            Token::Atom(ref a) => {
+                if let Token::Atom(a2) = other {
+                    return *a == *a2;
+                }
+            }
+            Token::Ident(ref i) => {
+                if let Token::Ident(i2) = other {
+                    return *i == *i2;
+                }
+            }
+            Token::String(ref s) => {
+                if let Token::String(s2) = other {
+                    return *s == *s2;
+                }
+            }
+            _ => return mem::discriminant(self) == mem::discriminant(other),
+        }
+        return false;
+    }
+}
+impl Eq for Token {}
+impl Hash for Token {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match *self {
+            Token::Float(n) => (n as u64).hash(state),
+            Token::Error(ref e) => e.hash(state),
+            Token::Atom(ref a) => a.hash(state),
+            Token::Ident(ref i) => i.hash(state),
+            Token::String(ref s) => s.hash(state),
+            Token::Char(c) => c.hash(state),
+            ref token => token.to_string().hash(state),
+        }
+    }
+}
+
+impl Token {
+    pub fn from_bare_atom<'input>(atom: &'input str) -> Self {
+        match atom.as_ref() {
+            // Reserved words
+            "after" => Token::After,
+            "begin" => Token::Begin,
+            "case" => Token::Case,
+            "try" => Token::Try,
+            "catch" => Token::Catch,
+            "end" => Token::End,
+            "fun" => Token::Fun,
+            "if" => Token::If,
+            "of" => Token::Of,
+            "receive" => Token::Receive,
+            "when" => Token::When,
+            "andalso" => Token::AndAlso,
+            "orelse" => Token::OrElse,
+            "bnot" => Token::Bnot,
+            "not" => Token::Not,
+            "div" => Token::Div,
+            "rem" => Token::Rem,
+            "band" => Token::Band,
+            "and" => Token::And,
+            "bor" => Token::Bor,
+            "bxor" => Token::Bxor,
+            "bsl" => Token::Bsl,
+            "bsr" => Token::Bsr,
+            "or" => Token::Or,
+            "xor" => Token::Xor,
+            _ => Token::Atom(Symbol::intern(atom)),
+        }
+    }
+}
+
+impl fmt::Display for Token {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Token::EOF => write!(f, "EOF"),
+            Token::Error(_) => write!(f, "ERROR"),
+            Token::Comment => write!(f, "COMMENT"),
+            Token::Edoc => write!(f, "EDOC"),
+            // Literals
+            Token::Char(ref c) => write!(f, "{}", c),
+            Token::Integer(ref i) => write!(f, "{}", i),
+            Token::BigInteger(ref i) => write!(f, "{}", i),
+            Token::Float(ref n) => write!(f, "{}", n),
+            Token::Atom(ref s) => write!(f, "'{}'", s),
+            Token::String(ref s) => write!(f, "\"{}\"", s),
+            Token::Ident(ref s) => write!(f, "{}", s),
+            Token::LParen => write!(f, "("),
+            Token::RParen => write!(f, ")"),
+            Token::Comma => write!(f, ","),
+            Token::RightStab => write!(f, "->"),
+            Token::LBrace => write!(f, "{{"),
+            Token::RBrace => write!(f, "}}"),
+            Token::LBracket => write!(f, "["),
+            Token::RBracket => write!(f, "]"),
+            Token::Bar => write!(f, "|"),
+            Token::BarBar => write!(f, "||"),
+            Token::LeftStab => write!(f, "<-"),
+            Token::Semicolon => write!(f, ";"),
+            Token::Colon => write!(f, ":"),
+            Token::Pound => write!(f, "#"),
+            Token::Dot => write!(f, "."),
+            Token::After => write!(f, "after"),
+            Token::Begin => write!(f, "begin"),
+            Token::Case => write!(f, "case"),
+            Token::Try => write!(f, "try"),
+            Token::Catch => write!(f, "catch"),
+            Token::End => write!(f, "end"),
+            Token::Fun => write!(f, "fun"),
+            Token::If => write!(f, "if"),
+            Token::Of => write!(f, "of"),
+            Token::Receive => write!(f, "receive"),
+            Token::When => write!(f, "when"),
+            Token::Record => write!(f, "record"),
+            Token::Spec => write!(f, "spec"),
+            Token::Callback => write!(f, "callback"),
+            Token::OptionalCallback => write!(f, "optional_callback"),
+            Token::Import => write!(f, "import"),
+            Token::Export => write!(f, "export"),
+            Token::ExportType => write!(f, "export_type"),
+            Token::Module => write!(f, "module"),
+            Token::Compile => write!(f, "compile"),
+            Token::Vsn => write!(f, "vsn"),
+            Token::OnLoad => write!(f, "on_load"),
+            Token::Behaviour => write!(f, "behaviour"),
+            Token::Deprecated => write!(f, "deprecated"),
+            Token::Type => write!(f, "type"),
+            Token::Opaque => write!(f, "opaque"),
+            Token::AndAlso => write!(f, "andalso"),
+            Token::OrElse => write!(f, "orelse"),
+            Token::Bnot => write!(f, "bnot"),
+            Token::Not => write!(f, "not"),
+            Token::Star => write!(f, "*"),
+            Token::Slash => write!(f, "/"),
+            Token::Div => write!(f, "div"),
+            Token::Rem => write!(f, "rem"),
+            Token::Band => write!(f, "band"),
+            Token::And => write!(f, "and"),
+            Token::Plus => write!(f, "+"),
+            Token::Minus => write!(f, "-"),
+            Token::Bor => write!(f, "bor"),
+            Token::Bxor => write!(f, "bxor"),
+            Token::Bsl => write!(f, "bsl"),
+            Token::Bsr => write!(f, "bsr"),
+            Token::Or => write!(f, "or"),
+            Token::Xor => write!(f, "xor"),
+            Token::PlusPlus => write!(f, "++"),
+            Token::MinusMinus => write!(f, "--"),
+            Token::IsEqual => write!(f, "=="),
+            Token::IsNotEqual => write!(f, "/="),
+            Token::IsLessThanOrEqual => write!(f, "=<"),
+            Token::IsLessThan => write!(f, "<"),
+            Token::IsGreaterThanOrEqual => write!(f, ">="),
+            Token::IsGreaterThan => write!(f, ">"),
+            Token::IsExactlyEqual => write!(f, "=:="),
+            Token::IsExactlyNotEqual => write!(f, "=/="),
+            Token::LeftArrow => write!(f, "<="),
+            Token::RightArrow => write!(f, "=>"),
+            Token::ColonEqual => write!(f, ":="),
+            Token::BinaryStart => write!(f, "<<"),
+            Token::BinaryEnd => write!(f, ">>"),
+            Token::Bang => write!(f, "!"),
+            Token::Equals => write!(f, "="),
+            Token::ColonColon => write!(f, "::"),
+            Token::DotDot => write!(f, ".."),
+            Token::DotDotDot => write!(f, "..."),
+            Token::Question => write!(f, "?"),
+            Token::DoubleQuestion => write!(f, "??"),
+        }
+    }
+}

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -1,0 +1,24 @@
+#![feature(box_patterns)]
+#![feature(box_syntax)]
+#![feature(core_intrinsics)]
+#![feature(custom_attribute)]
+#![feature(map_get_key_value)]
+#![feature(optin_builtin_traits)]
+#![feature(dropck_eyepatch)]
+#![feature(raw_vec_internals)]
+#![feature(test)]
+
+extern crate alloc;
+
+#[cfg(any(test, bench))]
+extern crate test;
+
+mod arena;
+mod lexer;
+mod parser;
+mod preprocessor;
+mod util;
+
+pub use self::lexer::*;
+pub use self::parser::*;
+pub use self::preprocessor::*;

--- a/frontend/src/parser.rs
+++ b/frontend/src/parser.rs
@@ -1,0 +1,652 @@
+/// Used in the grammar for easy span creation
+macro_rules! span {
+    ($l:expr, $r:expr) => {
+        ByteSpan::new($l, $r)
+    };
+    ($i:expr) => {
+        ByteSpan::new($i, $i)
+    };
+}
+
+/// Convenience function for building parser errors
+macro_rules! to_lalrpop_err (
+    ($error:expr) => (lalrpop_util::ParseError::User { error: $error })
+);
+
+#[cfg_attr(rustfmt, rustfmt_skip)]
+#[allow(unknown_lints)]
+#[allow(clippy)]
+pub(crate) mod grammar {
+    // During the build step, `build.rs` will output the generated parser to `OUT_DIR` to avoid
+    // adding it to the source directory, so we just directly include the generated parser here.
+    //
+    // Even with `.gitignore` and the `exclude` in the `Cargo.toml`, the generated parser can still
+    // end up in the source directory. This could happen when `cargo build` builds the file out of
+    // the Cargo cache (`$HOME/.cargo/registrysrc`), and the build script would then put its output
+    // in that cached source directory because of https://github.com/lalrpop/lalrpop/issues/280.
+    // Later runs of `cargo vendor` then copy the source from that directory, including the
+    // generated file.
+    include!(concat!(env!("OUT_DIR"), "/parser/grammar.rs"));
+}
+
+#[macro_use]
+mod macros;
+
+pub mod ast;
+mod errors;
+/// Contains the visitor trait needed to traverse the AST and helper walk functions.
+pub mod visitor;
+
+use std::borrow::Cow;
+use std::collections::{HashMap, VecDeque};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use diagnostics::{CodeMap, FileName};
+
+use crate::lexer::{FileMapSource, Lexer, Scanner, Source, Symbol};
+use crate::preprocessor::{MacroDef, Preprocessed, Preprocessor};
+
+pub use self::errors::*;
+
+/// The type of result returned from parsing functions
+pub type ParseResult<T> = Result<T, Vec<ParserError>>;
+
+pub struct Parser {
+    pub config: ParseConfig,
+}
+impl Parser {
+    pub fn new(config: ParseConfig) -> Parser {
+        Parser { config }
+    }
+
+    pub fn parse_string<S, T>(&self, source: S) -> ParseResult<T>
+    where
+        S: AsRef<str>,
+        T: Parse,
+    {
+        let filemap = {
+            self.config.codemap.lock().unwrap().add_filemap(
+                FileName::Virtual(Cow::Borrowed("nofile")),
+                source.as_ref().to_owned(),
+            )
+        };
+        <T as Parse<T>>::parse(&self.config, FileMapSource::new(filemap))
+    }
+
+    pub fn parse_file<P, T>(&self, path: P) -> ParseResult<T>
+    where
+        P: AsRef<Path>,
+        T: Parse,
+    {
+        match FileMapSource::from_path(self.config.codemap.clone(), path) {
+            Err(err) => return Err(vec![err.into()]),
+            Ok(source) => <T as Parse<T>>::parse(&self.config, source),
+        }
+    }
+}
+
+pub struct ParseConfig {
+    pub codemap: Arc<Mutex<CodeMap>>,
+    pub warnings_as_errors: bool,
+    pub no_warn: bool,
+    pub code_paths: VecDeque<PathBuf>,
+    pub macros: Option<HashMap<Symbol, MacroDef>>,
+}
+impl ParseConfig {
+    pub fn new(codemap: Arc<Mutex<CodeMap>>) -> Self {
+        ParseConfig {
+            codemap,
+            warnings_as_errors: false,
+            no_warn: false,
+            code_paths: VecDeque::new(),
+            macros: None,
+        }
+    }
+}
+impl Default for ParseConfig {
+    fn default() -> Self {
+        ParseConfig {
+            codemap: Arc::new(Mutex::new(CodeMap::new())),
+            warnings_as_errors: false,
+            no_warn: false,
+            code_paths: VecDeque::new(),
+            macros: None,
+        }
+    }
+}
+
+pub trait Parse<T = Self> {
+    type Parser;
+
+    /// Initializes a token stream for the underlying parser and invokes parse_tokens/1
+    fn parse<S>(config: &ParseConfig, source: S) -> ParseResult<T>
+    where
+        S: Source,
+    {
+        let scanner = Scanner::new(source);
+        let lexer = Lexer::new(scanner);
+        let tokens = Preprocessor::new(config, lexer);
+        Self::parse_tokens(tokens)
+    }
+
+    /// Implemented by each parser, which should parse the token stream and produce a T
+    fn parse_tokens<S: IntoIterator<Item = Preprocessed>>(tokens: S) -> ParseResult<T>;
+}
+
+impl Parse for ast::Module {
+    type Parser = grammar::ModuleParser;
+
+    fn parse_tokens<S: IntoIterator<Item = Preprocessed>>(tokens: S) -> ParseResult<ast::Module> {
+        let mut errs = Vec::new();
+        let result = Self::Parser::new()
+            .parse(&mut errs, tokens)
+            .map_err(|e| e.map_error(|ei| ei.into()));
+        to_parse_result(errs, result)
+    }
+}
+
+impl Parse for ast::Expr {
+    type Parser = grammar::ExprParser;
+
+    fn parse_tokens<S: IntoIterator<Item = Preprocessed>>(tokens: S) -> ParseResult<ast::Expr> {
+        let mut errs = Vec::new();
+        let result = Self::Parser::new()
+            .parse(&mut errs, tokens)
+            .map_err(|e| e.map_error(|ei| ei.into()));
+        to_parse_result(errs, result)
+    }
+}
+
+fn to_parse_result<T>(mut errs: Vec<ParseError>, result: Result<T, ParseError>) -> ParseResult<T> {
+    match result {
+        Ok(ast) => {
+            if errs.len() > 0 {
+                return Err(errs.drain(0..).map(ParserError::from).collect());
+            }
+            Ok(ast)
+        }
+        Err(err) => {
+            errs.push(err);
+            Err(errs.drain(0..).map(ParserError::from).collect())
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use pretty_assertions::assert_eq;
+
+    use super::ast::*;
+    use super::*;
+
+    use diagnostics::ByteSpan;
+    use diagnostics::{ColorChoice, Emitter, StandardStreamEmitter};
+
+    use crate::lexer::{Ident, Symbol};
+    use crate::preprocessor::PreprocessorError;
+
+    fn parse<T>(input: &'static str) -> T
+    where
+        T: Parse<T>,
+    {
+        let config = ParseConfig::default();
+        let parser = Parser::new(config);
+        let errs = match parser.parse_string::<&'static str, T>(input) {
+            Ok(ast) => return ast,
+            Err(errs) => errs,
+        };
+        let emitter = StandardStreamEmitter::new(ColorChoice::Auto)
+            .set_codemap(parser.config.codemap.clone());
+        for err in errs.iter() {
+            emitter.diagnostic(&err.to_diagnostic()).unwrap();
+        }
+        panic!("parse failed");
+    }
+
+    fn parse_fail<T>(input: &'static str) -> Vec<ParserError>
+    where
+        T: Parse<T>,
+    {
+        let config = ParseConfig::default();
+        let parser = Parser::new(config);
+        match parser.parse_string::<&'static str, T>(input) {
+            Err(errs) => errs,
+            _ => panic!("expected parse to fail, but it succeeded!"),
+        }
+    }
+
+    macro_rules! module {
+        ($name:expr, $body:expr) => {{
+            let mut errs = Vec::new();
+            let module = Module::new(&mut errs, ByteSpan::default(), $name, $body);
+            if errs.len() > 0 {
+                let emitter = StandardStreamEmitter::new(ColorChoice::Auto);
+                for err in errs.drain(..) {
+                    let err = ParserError::from(err);
+                    emitter.diagnostic(&err.to_diagnostic()).unwrap();
+                }
+                panic!("failed to create expected module!");
+            }
+            module
+        }};
+    }
+
+    #[test]
+    fn parse_empty_module() {
+        let result: Module = parse("-module(foo).");
+        let expected = module!(ident!("foo"), vec![]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn parse_module_with_multi_clause_function() {
+        let result: Module = parse(
+            "-module(foo).
+
+foo([], Acc) -> Acc;
+foo([H|T], Acc) -> foo(T, [H|Acc]).
+",
+        );
+        let mut clauses = Vec::new();
+        clauses.push(FunctionClause {
+            span: ByteSpan::default(),
+            name: ident_opt!(foo),
+            params: vec![nil!(), var!(Acc)],
+            guard: None,
+            body: vec![var!(Acc)],
+        });
+        clauses.push(FunctionClause {
+            span: ByteSpan::default(),
+            name: ident_opt!(foo),
+            params: vec![cons!(var!(H), var!(T)), var!(Acc)],
+            guard: None,
+            body: vec![apply!(atom!(foo), var!(T), cons!(var!(H), var!(Acc)))],
+        });
+        let mut body = Vec::new();
+        body.push(TopLevel::Function(NamedFunction {
+            span: ByteSpan::default(),
+            name: ident!("foo"),
+            arity: 2,
+            clauses,
+            spec: None,
+        }));
+        let expected = module!(ident!(foo), body);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn parse_if_expressions() {
+        let result: Module = parse(
+            "-module(foo).
+
+unless(false) ->
+    true;
+unless(true) ->
+    false;
+unless(Value) ->
+    if
+        Value == 0 -> true;
+        Value -> false;
+        else -> true
+    end.
+
+",
+        );
+        let mut clauses = Vec::new();
+        clauses.push(FunctionClause {
+            span: ByteSpan::default(),
+            name: ident_opt!(unless),
+            params: vec![atom!(false)],
+            guard: None,
+            body: vec![atom!(true)],
+        });
+        clauses.push(FunctionClause {
+            span: ByteSpan::default(),
+            name: ident_opt!(unless),
+            params: vec![atom!(true)],
+            guard: None,
+            body: vec![atom!(false)],
+        });
+        clauses.push(FunctionClause {
+            span: ByteSpan::default(),
+            name: ident_opt!(unless),
+            params: vec![var!(Value)],
+            guard: None,
+            body: vec![Expr::If(If {
+                span: ByteSpan::default(),
+                clauses: vec![
+                    IfClause {
+                        span: ByteSpan::default(),
+                        conditions: vec![Expr::BinaryExpr(BinaryExpr {
+                            span: ByteSpan::default(),
+                            lhs: Box::new(var!(Value)),
+                            op: BinaryOp::Equal,
+                            rhs: Box::new(int!(0)),
+                        })],
+                        body: vec![atom!(true)],
+                    },
+                    IfClause {
+                        span: ByteSpan::default(),
+                        conditions: vec![var!(Value)],
+                        body: vec![atom!(false)],
+                    },
+                    IfClause {
+                        span: ByteSpan::default(),
+                        conditions: vec![atom!(else)],
+                        body: vec![atom!(true)],
+                    },
+                ],
+            })],
+        });
+        let mut body = Vec::new();
+        body.push(TopLevel::Function(NamedFunction {
+            span: ByteSpan::default(),
+            name: ident!(unless),
+            arity: 1,
+            clauses,
+            spec: None,
+        }));
+        let expected = module!(ident!(foo), body);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn parse_case_expressions() {
+        let result: Module = parse(
+            "-module(foo).
+
+typeof(Value) ->
+    case Value of
+        [] -> nil;
+        [_|_] -> list;
+        N when is_number(N) -> N;
+        _ -> other
+    end.
+
+",
+        );
+        let mut clauses = Vec::new();
+        clauses.push(FunctionClause {
+            span: ByteSpan::default(),
+            name: ident_opt!(typeof),
+            params: vec![var!(Value)],
+            guard: None,
+            body: vec![Expr::Case(Case {
+                span: ByteSpan::default(),
+                expr: Box::new(var!(Value)),
+                clauses: vec![
+                    Clause {
+                        span: ByteSpan::default(),
+                        pattern: nil!(),
+                        guard: None,
+                        body: vec![atom!(nil)],
+                    },
+                    Clause {
+                        span: ByteSpan::default(),
+                        pattern: cons!(var!(_), var!(_)),
+                        guard: None,
+                        body: vec![atom!(list)],
+                    },
+                    Clause {
+                        span: ByteSpan::default(),
+                        pattern: var!(N),
+                        guard: Some(vec![Guard {
+                            span: ByteSpan::default(),
+                            conditions: vec![apply!(atom!(is_number), var!(N))],
+                        }]),
+                        body: vec![var!(N)],
+                    },
+                    Clause {
+                        span: ByteSpan::default(),
+                        pattern: var!(_),
+                        guard: None,
+                        body: vec![atom!(other)],
+                    },
+                ],
+            })],
+        });
+        let mut body = Vec::new();
+        body.push(TopLevel::Function(NamedFunction {
+            span: ByteSpan::default(),
+            name: ident!(typeof),
+            arity: 1,
+            clauses,
+            spec: None,
+        }));
+        let expected = module!(ident!(foo), body);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn parse_receive_expressions() {
+        let result: Module = parse(
+            "-module(foo).
+
+loop(State, Timeout) ->
+    receive
+        {From, {Ref, Msg}} ->
+            From ! {Ref, ok},
+            handle_info(Msg, State);
+        _ ->
+            exit(io_lib:format(\"unexpected message: ~p~n\", [Msg]))
+    after
+        Timeout ->
+            timeout
+    end.
+",
+        );
+        let mut clauses = Vec::new();
+        clauses.push(FunctionClause {
+            span: ByteSpan::default(),
+            name: ident_opt!(loop),
+            params: vec![var!(State), var!(Timeout)],
+            guard: None,
+            body: vec![Expr::Receive(Receive {
+                span: ByteSpan::default(),
+                clauses: Some(vec![
+                    Clause {
+                        span: ByteSpan::default(),
+                        pattern: tuple!(var!(From), tuple!(var!(Ref), var!(Msg))),
+                        guard: None,
+                        body: vec![
+                            Expr::BinaryExpr(BinaryExpr {
+                                span: ByteSpan::default(),
+                                lhs: Box::new(var!(From)),
+                                op: BinaryOp::Send,
+                                rhs: Box::new(tuple!(var!(Ref), atom!(ok))),
+                            }),
+                            apply!(atom!(handle_info), var!(Msg), var!(State)),
+                        ],
+                    },
+                    Clause {
+                        span: ByteSpan::default(),
+                        pattern: var!(_),
+                        guard: None,
+                        body: vec![apply!(
+                            atom!(exit),
+                            apply!(
+                                remote!(io_lib, format),
+                                Expr::Literal(Literal::String(ident!("unexpected message: ~p~n"))),
+                                cons!(var!(Msg), nil!())
+                            )
+                        )],
+                    },
+                ]),
+                after: Some(After {
+                    span: ByteSpan::default(),
+                    timeout: Box::new(var!(Timeout)),
+                    body: vec![atom!(timeout)],
+                }),
+            })],
+        });
+        let mut body = Vec::new();
+        body.push(TopLevel::Function(NamedFunction {
+            span: ByteSpan::default(),
+            name: ident!(loop),
+            arity: 2,
+            clauses,
+            spec: None,
+        }));
+        let expected = module!(ident!(foo), body);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn parse_preprocessor_if() {
+        let result: Module = parse(
+            "-module(foo).
+-define(TEST, true).
+-define(OTP_VERSION, 21).
+
+-ifdef(TEST).
+env() ->
+    test.
+-else.
+env() ->
+    release.
+-endif.
+
+-if(?OTP_VERSION > 21).
+system_version() ->
+    future.
+-elif(?OTP_VERSION == 21).
+system_version() ->
+    ?OTP_VERSION.
+-else.
+system_version() ->
+    old.
+-endif.
+",
+        );
+        let mut body = Vec::new();
+        let mut clauses = Vec::new();
+        clauses.push(FunctionClause {
+            span: ByteSpan::default(),
+            name: ident_opt!(env),
+            params: vec![],
+            guard: None,
+            body: vec![atom!(test)],
+        });
+        let env_fun = NamedFunction {
+            span: ByteSpan::default(),
+            name: ident!(env),
+            arity: 0,
+            clauses,
+            spec: None,
+        };
+        body.push(TopLevel::Function(env_fun));
+
+        let mut clauses = Vec::new();
+        clauses.push(FunctionClause {
+            span: ByteSpan::default(),
+            name: ident_opt!(system_version),
+            params: vec![],
+            guard: None,
+            body: vec![int!(21)],
+        });
+        let system_version_fun = NamedFunction {
+            span: ByteSpan::default(),
+            name: ident!(system_version),
+            arity: 0,
+            clauses,
+            spec: None,
+        };
+        body.push(TopLevel::Function(system_version_fun));
+        let expected = module!(ident!(foo), body);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn parse_preprocessor_warning_error() {
+        // NOTE: Warnings are not printed with cfg(test), as we
+        // cannot control where they end up without refactoring to pass
+        // a writer everywhere. You can change this for testing by
+        // going to the Preprocessor and finding the line where we handle
+        // the warning directive and toggle the config flag
+        let mut errs = parse_fail::<Module>(
+            "-module(foo).
+-warning(\"this is a compiler warning\").
+-error(\"this is a compiler error\").
+",
+        );
+        match errs.pop() {
+            Some(ParserError::Preprocessor(PreprocessorError::CompilerError(_, _))) => (),
+            Some(err) => panic!(
+                "expected compiler error, but got a different error instead: {:?}",
+                err
+            ),
+            None => panic!("expected compiler error, but didn't get any errors!"),
+        }
+    }
+
+    #[test]
+    fn parse_try() {
+        let result: Module = parse(
+            "-module(foo).
+
+example(File) ->
+    try read(File) of
+        {ok, Contents} ->
+            {ok, Contents}
+    catch
+        error:{Mod, Code} ->
+            {error, Mod:format_error(Code)};
+        Reason ->
+            {error, Reason}
+    after
+        close(File)
+    end.
+",
+        );
+        let mut clauses = Vec::new();
+        clauses.push(FunctionClause {
+            span: ByteSpan::default(),
+            name: ident_opt!(example),
+            params: vec![var!(File)],
+            guard: None,
+            body: vec![Expr::Try(Try {
+                span: ByteSpan::default(),
+                exprs: Some(vec![apply!(atom!(read), var!(File))]),
+                clauses: Some(vec![Clause {
+                    span: ByteSpan::default(),
+                    pattern: tuple!(atom!(ok), var!(Contents)),
+                    guard: None,
+                    body: vec![tuple!(atom!(ok), var!(Contents))],
+                }]),
+                catch_clauses: Some(vec![
+                    TryClause {
+                        span: ByteSpan::default(),
+                        kind: Name::Atom(ident!(error)),
+                        error: tuple!(var!(Mod), var!(Code)),
+                        trace: ident!(_),
+                        guard: None,
+                        body: vec![tuple!(
+                            atom!(error),
+                            apply!(remote!(var!(Mod), atom!(format_error)), var!(Code))
+                        )],
+                    },
+                    TryClause {
+                        span: ByteSpan::default(),
+                        kind: Name::Atom(ident!(throw)),
+                        error: var!(Reason),
+                        trace: ident!(_),
+                        guard: None,
+                        body: vec![tuple!(atom!(error), var!(Reason))],
+                    },
+                ]),
+                after: Some(vec![apply!(atom!(close), var!(File))]),
+            })],
+        });
+        let mut body = Vec::new();
+        body.push(TopLevel::Function(NamedFunction {
+            span: ByteSpan::default(),
+            name: ident!(example),
+            arity: 1,
+            clauses,
+            spec: None,
+        }));
+        let expected = module!(ident!(foo), body);
+        assert_eq!(result, expected);
+    }
+}

--- a/frontend/src/parser/ast.rs
+++ b/frontend/src/parser/ast.rs
@@ -1,0 +1,92 @@
+mod attributes;
+mod expr;
+mod functions;
+mod module;
+mod types;
+
+use diagnostics::ByteIndex;
+
+pub use self::attributes::*;
+pub use self::expr::*;
+pub use self::functions::*;
+pub use self::module::*;
+pub use self::types::*;
+pub use super::{ParseError, ParserError};
+pub use crate::lexer::{Ident, Symbol};
+
+use crate::lexer::Token;
+use crate::preprocessor::PreprocessorError;
+
+/// Used for AST functions which need to raise an error to the parser directly
+pub type TryParseResult<T> =
+    Result<T, lalrpop_util::ParseError<ByteIndex, Token, PreprocessorError>>;
+
+/// Represents either a concrete name (an atom) or a variable name (an identifier).
+/// This is used in constructs where either are permitted.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Name {
+    Atom(Ident),
+    Var(Ident),
+}
+impl Name {
+    pub fn symbol(&self) -> Symbol {
+        match self {
+            Name::Atom(Ident { ref name, .. }) => name.clone(),
+            Name::Var(Ident { ref name, .. }) => name.clone(),
+        }
+    }
+}
+impl PartialOrd for Name {
+    fn partial_cmp(&self, other: &Name) -> Option<std::cmp::Ordering> {
+        self.symbol().partial_cmp(&other.symbol())
+    }
+}
+
+/// The set of all binary operators which may be used in expressions
+#[derive(Debug, Clone, PartialEq)]
+pub enum BinaryOp {
+    // 100 !, right associative
+    Send,
+    // 150 orelse
+    OrElse,
+    // 160 andalso
+    AndAlso,
+    // 200 <all comparison operators>
+    Equal, // right associative
+    NotEqual,
+    Lte,
+    Lt,
+    Gte,
+    Gt,
+    StrictEqual,
+    StrictNotEqual,
+    // 300 <all list operators>, right associative
+    Append,
+    Remove,
+    // 400 <all add operators>, left associative
+    Add,
+    Sub,
+    Bor,
+    Bxor,
+    Bsl,
+    Bsr,
+    Or,
+    Xor,
+    // 500 <all mul operators>, left associative
+    Divide,
+    Multiply,
+    Div,
+    Rem,
+    Band,
+    And,
+}
+
+/// The set of all unary (prefix) operators which may be used in expressions
+#[derive(Debug, Clone, PartialEq)]
+pub enum UnaryOp {
+    // 600 <all prefix operators>
+    Plus,
+    Minus,
+    Bnot,
+    Not,
+}

--- a/frontend/src/parser/ast/attributes.rs
+++ b/frontend/src/parser/ast/attributes.rs
@@ -1,0 +1,248 @@
+use std::fmt;
+use std::hash::{Hash, Hasher};
+
+use diagnostics::ByteSpan;
+
+use super::{Expr, Ident, PartiallyResolvedFunctionName, Type};
+
+/// Type definitions
+///
+/// ## Examples
+///
+/// ```text
+/// %% Simple types
+/// -type foo() :: bar.
+/// -opaque foo() :: bar.
+///
+/// %% Generic/parameterized types
+/// -type foo(T) :: [T].
+/// -opaque foo(T) :: [T].
+/// ```
+#[derive(Debug, Clone)]
+pub struct TypeDef {
+    pub span: ByteSpan,
+    pub opaque: bool,
+    pub name: Ident,
+    pub params: Vec<Ident>,
+    pub ty: Type,
+}
+impl PartialEq for TypeDef {
+    fn eq(&self, other: &Self) -> bool {
+        if self.opaque != other.opaque {
+            return false;
+        }
+        if self.name != other.name {
+            return false;
+        }
+        if self.params != other.params {
+            return false;
+        }
+        if self.ty != other.ty {
+            return false;
+        }
+        return true;
+    }
+}
+
+/// Function type specifications, used for both function specs and callback specs
+///
+/// ## Example
+///
+/// ```text
+/// %% Monomorphic function
+/// -spec foo(A :: map(), Opts :: list({atom(), term()})) -> {ok, map()} | {error, term()}.
+///
+/// %% Polymorphic function
+/// -spec foo(A, Opts :: list({atom, term()})) -> {ok, A} | {error, term()}.
+///
+/// %% Multiple dispatch function
+/// -spec foo(map(), Opts) -> {ok, map()} | {error, term()};
+///   foo(list(), Opts) -> {ok, list()} | {error, term()}.
+///
+/// %% Using `when` to express subtype constraints
+/// -spec foo(map(), Opts) -> {ok, map()} | {error, term()}
+///   when Opts :: list({atom, term});
+/// ```
+#[derive(Debug, Clone)]
+pub struct TypeSpec {
+    pub span: ByteSpan,
+    pub module: Option<Ident>,
+    pub function: Ident,
+    pub sigs: Vec<TypeSig>,
+}
+impl PartialEq for TypeSpec {
+    fn eq(&self, other: &Self) -> bool {
+        self.module == other.module && self.function == other.function && self.sigs == other.sigs
+    }
+}
+
+/// A callback declaration, which is functionally identical to `TypeSpec` in
+/// its syntax, but is used to both define a callback function for a behaviour,
+/// as well as provide an expected type specification for that function.
+#[derive(Debug, Clone)]
+pub struct Callback {
+    pub span: ByteSpan,
+    pub optional: bool,
+    pub module: Option<Ident>,
+    pub function: Ident,
+    pub sigs: Vec<TypeSig>,
+}
+impl PartialEq for Callback {
+    fn eq(&self, other: &Self) -> bool {
+        self.optional == other.optional
+            && self.module == other.module
+            && self.function == other.function
+            && self.sigs == other.sigs
+    }
+}
+
+/// Contains type information for a single clause of a function type specification
+#[derive(Debug, Clone, PartialEq)]
+pub struct TypeSig {
+    pub span: ByteSpan,
+    pub params: Vec<Type>,
+    pub ret: Box<Type>,
+    pub guards: Option<Vec<TypeGuard>>,
+}
+
+/// Contains a single subtype constraint to be applied to a type specification
+#[derive(Debug, Clone)]
+pub struct TypeGuard {
+    pub span: ByteSpan,
+    pub var: Ident,
+    pub ty: Type,
+}
+impl PartialEq for TypeGuard {
+    fn eq(&self, other: &TypeGuard) -> bool {
+        self.var == other.var && self.ty == other.ty
+    }
+}
+
+/// Represents a user-defined custom attribute.
+///
+/// ## Example
+///
+/// ```text
+/// -my_attribute([foo, bar]).
+/// ```
+#[derive(Debug, Clone)]
+pub struct UserAttribute {
+    pub span: ByteSpan,
+    pub name: Ident,
+    pub value: Expr,
+}
+impl PartialEq for UserAttribute {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.value == other.value
+    }
+}
+
+/// Represents a deprecated function or module
+#[derive(Debug, Clone)]
+pub enum Deprecation {
+    Module {
+        span: ByteSpan,
+        flag: DeprecatedFlag,
+    },
+    Function {
+        span: ByteSpan,
+        function: PartiallyResolvedFunctionName,
+        flag: DeprecatedFlag,
+    },
+}
+impl Deprecation {
+    pub fn span(&self) -> ByteSpan {
+        match self {
+            &Deprecation::Module { ref span, .. } => span.clone(),
+            &Deprecation::Function { ref span, .. } => span.clone(),
+        }
+    }
+}
+impl PartialEq for Deprecation {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (&Deprecation::Module { .. }, &Deprecation::Module { .. }) => true,
+            // We ignore the flag because it used only for display,
+            // the function/arity determines equality
+            (
+                &Deprecation::Function {
+                    function: ref x1, ..
+                },
+                &Deprecation::Function {
+                    function: ref y1, ..
+                },
+            ) => x1 == y1,
+            _ => false,
+        }
+    }
+}
+impl Eq for Deprecation {}
+impl Hash for Deprecation {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let discriminant = std::mem::discriminant(self);
+        discriminant.hash(state);
+        match self {
+            &Deprecation::Module { .. } => (),
+            &Deprecation::Function { ref function, .. } => function.hash(state),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeprecatedFlag {
+    Eventually,
+    NextVersion,
+    NextMajorRelease,
+}
+impl fmt::Display for DeprecatedFlag {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            &DeprecatedFlag::Eventually => write!(f, "eventually"),
+            &DeprecatedFlag::NextVersion => write!(f, "in the next version"),
+            &DeprecatedFlag::NextMajorRelease => write!(f, "in the next major release"),
+        }
+    }
+}
+
+/// Represents the set of allowed attributes in the body of a module
+#[derive(Debug, Clone)]
+pub enum Attribute {
+    Type(TypeDef),
+    Spec(TypeSpec),
+    Callback(Callback),
+    Custom(UserAttribute),
+    ExportType(ByteSpan, Vec<PartiallyResolvedFunctionName>),
+    Export(ByteSpan, Vec<PartiallyResolvedFunctionName>),
+    Import(ByteSpan, Ident, Vec<PartiallyResolvedFunctionName>),
+    Compile(ByteSpan, Expr),
+    Vsn(ByteSpan, Expr),
+    OnLoad(ByteSpan, PartiallyResolvedFunctionName),
+    Behaviour(ByteSpan, Ident),
+    Deprecation(Vec<Deprecation>),
+}
+impl PartialEq for Attribute {
+    fn eq(&self, other: &Attribute) -> bool {
+        let left = std::mem::discriminant(self);
+        let right = std::mem::discriminant(other);
+        if left != right {
+            return false;
+        }
+
+        match (self, other) {
+            (&Attribute::Type(ref x), &Attribute::Type(ref y)) => x == y,
+            (&Attribute::Spec(ref x), &Attribute::Spec(ref y)) => x == y,
+            (&Attribute::Callback(ref x), &Attribute::Callback(ref y)) => x == y,
+            (&Attribute::Custom(ref x), &Attribute::Custom(ref y)) => x == y,
+            (&Attribute::ExportType(_, ref x), &Attribute::ExportType(_, ref y)) => x == y,
+            (&Attribute::Export(_, ref x), &Attribute::Export(_, ref y)) => x == y,
+            (&Attribute::Import(_, ref x1, ref x2), &Attribute::Import(_, ref y1, ref y2)) => {
+                (x1 == y1) && (x2 == y2)
+            }
+            (&Attribute::Compile(_, ref x), &Attribute::Compile(_, ref y)) => x == y,
+            (&Attribute::Vsn(_, ref x), &Attribute::Vsn(_, ref y)) => x == y,
+            (&Attribute::OnLoad(_, ref x), &Attribute::OnLoad(_, ref y)) => x == y,
+            (&Attribute::Behaviour(_, ref x), &Attribute::Behaviour(_, ref y)) => x == y,
+            _ => false,
+        }
+    }
+}

--- a/frontend/src/parser/ast/expr.rs
+++ b/frontend/src/parser/ast/expr.rs
@@ -1,0 +1,678 @@
+use std::cmp::Ordering;
+
+use diagnostics::ByteSpan;
+use rug::Integer;
+
+use super::{BinaryOp, Ident, UnaryOp};
+use super::{Function, FunctionName, Guard, Name, Type};
+
+/// The set of all possible expressions
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expr {
+    // An identifier/variable/function reference
+    Var(Ident),
+    Literal(Literal),
+    FunctionName(FunctionName),
+    // The various list forms
+    Nil(Nil),
+    Cons(Cons),
+    // Other data structures
+    Tuple(Tuple),
+    Map(Map),
+    MapUpdate(MapUpdate),
+    MapProjection(MapProjection),
+    Binary(Binary),
+    Record(Record),
+    RecordAccess(RecordAccess),
+    RecordIndex(RecordIndex),
+    RecordUpdate(RecordUpdate),
+    // Comprehensions
+    ListComprehension(ListComprehension),
+    BinaryComprehension(BinaryComprehension),
+    Generator(Generator),
+    BinaryGenerator(BinaryGenerator),
+    // Complex expressions
+    Begin(Begin),
+    Apply(Apply),
+    Remote(Remote),
+    BinaryExpr(BinaryExpr),
+    UnaryExpr(UnaryExpr),
+    Match(Match),
+    If(If),
+    Catch(Catch),
+    Case(Case),
+    Receive(Receive),
+    Try(Try),
+    Fun(Function),
+}
+impl Expr {
+    pub fn span(&self) -> ByteSpan {
+        match self {
+            &Expr::Var(Ident { ref span, .. }) => span.clone(),
+            &Expr::Literal(ref lit) => lit.span(),
+            &Expr::FunctionName(ref name) => name.span(),
+            &Expr::Nil(Nil(ref span)) => span.clone(),
+            &Expr::Cons(Cons { ref span, .. }) => span.clone(),
+            &Expr::Tuple(Tuple { ref span, .. }) => span.clone(),
+            &Expr::Map(Map { ref span, .. }) => span.clone(),
+            &Expr::MapUpdate(MapUpdate { ref span, .. }) => span.clone(),
+            &Expr::MapProjection(MapProjection { ref span, .. }) => span.clone(),
+            &Expr::Binary(Binary { ref span, .. }) => span.clone(),
+            &Expr::Record(Record { ref span, .. }) => span.clone(),
+            &Expr::RecordAccess(RecordAccess { ref span, .. }) => span.clone(),
+            &Expr::RecordIndex(RecordIndex { ref span, .. }) => span.clone(),
+            &Expr::RecordUpdate(RecordUpdate { ref span, .. }) => span.clone(),
+            &Expr::ListComprehension(ListComprehension { ref span, .. }) => span.clone(),
+            &Expr::BinaryComprehension(BinaryComprehension { ref span, .. }) => span.clone(),
+            &Expr::Generator(Generator { ref span, .. }) => span.clone(),
+            &Expr::BinaryGenerator(BinaryGenerator { ref span, .. }) => span.clone(),
+            &Expr::Begin(Begin { ref span, .. }) => span.clone(),
+            &Expr::Apply(Apply { ref span, .. }) => span.clone(),
+            &Expr::Remote(Remote { ref span, .. }) => span.clone(),
+            &Expr::BinaryExpr(BinaryExpr { ref span, .. }) => span.clone(),
+            &Expr::UnaryExpr(UnaryExpr { ref span, .. }) => span.clone(),
+            &Expr::Match(Match { ref span, .. }) => span.clone(),
+            &Expr::If(If { ref span, .. }) => span.clone(),
+            &Expr::Catch(Catch { ref span, .. }) => span.clone(),
+            &Expr::Case(Case { ref span, .. }) => span.clone(),
+            &Expr::Receive(Receive { ref span, .. }) => span.clone(),
+            &Expr::Try(Try { ref span, .. }) => span.clone(),
+            &Expr::Fun(ref fun) => fun.span(),
+        }
+    }
+}
+impl PartialOrd for Expr {
+    // number < atom < reference < fun < port < pid < tuple < map < nil < list < bit string
+    fn partial_cmp(&self, other: &Expr) -> Option<Ordering> {
+        match (self, other) {
+            (&Expr::Binary(_), &Expr::Binary(_)) => None,
+            (&Expr::Binary(_), _) => Some(Ordering::Greater),
+            (_, &Expr::Binary(_)) => Some(Ordering::Less),
+            (&Expr::Cons(ref lhs), &Expr::Cons(ref rhs)) => lhs.partial_cmp(rhs),
+            (&Expr::Cons(_), _) => Some(Ordering::Greater),
+            (_, &Expr::Cons(_)) => Some(Ordering::Less),
+            (&Expr::Nil(_), &Expr::Nil(_)) => Some(Ordering::Equal),
+            (&Expr::Nil(_), _) => Some(Ordering::Greater),
+            (_, &Expr::Nil(_)) => Some(Ordering::Less),
+            (&Expr::Map(ref lhs), &Expr::Map(ref rhs)) => lhs.partial_cmp(rhs),
+            (&Expr::Map(_), _) => Some(Ordering::Greater),
+            (_, &Expr::Map(_)) => Some(Ordering::Less),
+            (&Expr::Tuple(ref lhs), &Expr::Tuple(ref rhs)) => lhs.partial_cmp(rhs),
+            (&Expr::Tuple(_), _) => Some(Ordering::Greater),
+            (_, &Expr::Tuple(_)) => Some(Ordering::Less),
+            (&Expr::Fun(_), &Expr::Fun(_)) => None,
+            (&Expr::Fun(_), _) => Some(Ordering::Greater),
+            (_, &Expr::Fun(_)) => Some(Ordering::Less),
+            (&Expr::Literal(ref lhs), &Expr::Literal(ref rhs)) => lhs.partial_cmp(rhs),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Nil(pub ByteSpan);
+impl PartialEq for Nil {
+    fn eq(&self, _: &Self) -> bool {
+        return true;
+    }
+}
+impl Eq for Nil {}
+
+#[derive(Debug, Clone)]
+pub struct Cons {
+    pub span: ByteSpan,
+    pub head: Box<Expr>,
+    pub tail: Box<Expr>,
+}
+impl PartialEq for Cons {
+    fn eq(&self, other: &Self) -> bool {
+        self.head == other.head && self.tail == other.tail
+    }
+}
+impl PartialOrd for Cons {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match self.head.partial_cmp(&other.head) {
+            None => self.tail.partial_cmp(&other.tail),
+            Some(order) => Some(order),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Tuple {
+    pub span: ByteSpan,
+    pub elements: Vec<Expr>,
+}
+impl PartialEq for Tuple {
+    fn eq(&self, other: &Self) -> bool {
+        self.elements == other.elements
+    }
+}
+impl PartialOrd for Tuple {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.elements.partial_cmp(&other.elements)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Map {
+    pub span: ByteSpan,
+    pub fields: Vec<MapField>,
+}
+impl PartialEq for Map {
+    fn eq(&self, other: &Self) -> bool {
+        self.fields == other.fields
+    }
+}
+impl PartialOrd for Map {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.fields.partial_cmp(&other.fields)
+    }
+}
+
+// Updating fields on an existing map, e.g. `Map#{field1 = value1}.`
+#[derive(Debug, Clone)]
+pub struct MapUpdate {
+    pub span: ByteSpan,
+    pub map: Box<Expr>,
+    pub updates: Vec<MapField>,
+}
+impl PartialEq for MapUpdate {
+    fn eq(&self, other: &Self) -> bool {
+        self.map == other.map && self.updates == other.updates
+    }
+}
+
+// Pattern matching a map expression
+#[derive(Debug, Clone)]
+pub struct MapProjection {
+    pub span: ByteSpan,
+    pub map: Box<Expr>,
+    pub fields: Vec<MapField>,
+}
+impl PartialEq for MapProjection {
+    fn eq(&self, other: &Self) -> bool {
+        self.map == other.map && self.fields == other.fields
+    }
+}
+
+/// The set of literal values
+///
+/// This does not include tuples, lists, and maps,
+/// even though those can be constructed at compile-time,
+/// as some places that allow literals do not permit those
+/// types
+#[derive(Debug, Clone)]
+pub enum Literal {
+    Atom(Ident),
+    String(Ident),
+    Char(ByteSpan, char),
+    Integer(ByteSpan, i64),
+    BigInteger(ByteSpan, Integer),
+    Float(ByteSpan, f64),
+}
+impl Literal {
+    pub fn span(&self) -> ByteSpan {
+        match self {
+            &Literal::Atom(Ident { ref span, .. }) => span.clone(),
+            &Literal::String(Ident { ref span, .. }) => span.clone(),
+            &Literal::Char(ref span, _) => span.clone(),
+            &Literal::Integer(ref span, _) => span.clone(),
+            &Literal::BigInteger(ref span, _) => span.clone(),
+            &Literal::Float(ref span, _) => span.clone(),
+        }
+    }
+}
+impl PartialEq for Literal {
+    fn eq(&self, other: &Literal) -> bool {
+        match (self, other) {
+            (&Literal::Atom(ref lhs), &Literal::Atom(ref rhs)) => lhs == rhs,
+            (&Literal::Atom(_), _) => false,
+            (_, &Literal::Atom(_)) => false,
+            (&Literal::String(ref lhs), &Literal::String(ref rhs)) => lhs == rhs,
+            (&Literal::String(_), _) => false,
+            (_, &Literal::String(_)) => false,
+            (x, y) => x.partial_cmp(y) == Some(Ordering::Equal),
+        }
+    }
+}
+impl PartialOrd for Literal {
+    // number < atom < reference < fun < port < pid < tuple < map < nil < list < bit string
+    fn partial_cmp(&self, other: &Literal) -> Option<Ordering> {
+        match (self, other) {
+            (&Literal::String(ref lhs), &Literal::String(ref rhs)) => lhs.partial_cmp(rhs),
+            (&Literal::String(_), _) => Some(Ordering::Greater),
+            (_, &Literal::String(_)) => Some(Ordering::Less),
+            (&Literal::Atom(ref lhs), &Literal::Atom(ref rhs)) => lhs.partial_cmp(rhs),
+            (&Literal::Atom(_), _) => Some(Ordering::Greater),
+            (_, &Literal::Atom(_)) => Some(Ordering::Less),
+            (&Literal::Integer(_, x), &Literal::Integer(_, y)) => x.partial_cmp(&y),
+            (&Literal::Integer(_, x), &Literal::BigInteger(_, ref y)) => x.partial_cmp(y),
+            (&Literal::Integer(_, x), &Literal::Float(_, y)) => (x as f64).partial_cmp(&y),
+            (&Literal::Integer(_, x), &Literal::Char(_, y)) => x.partial_cmp(&(y as i64)),
+            (&Literal::BigInteger(_, ref x), &Literal::BigInteger(_, ref y)) => x.partial_cmp(y),
+            (&Literal::BigInteger(_, ref x), &Literal::Integer(_, y)) => x.partial_cmp(&y),
+            (&Literal::BigInteger(_, ref x), &Literal::Float(_, y)) => x.partial_cmp(&y),
+            (&Literal::BigInteger(_, ref x), &Literal::Char(_, y)) => x.partial_cmp(&(y as i64)),
+            (&Literal::Float(_, x), &Literal::Float(_, y)) => x.partial_cmp(&y),
+            (&Literal::Float(_, x), &Literal::Integer(_, y)) => x.partial_cmp(&(y as f64)),
+            (&Literal::Float(_, x), &Literal::BigInteger(_, ref y)) => x.partial_cmp(y),
+            (&Literal::Float(_, x), &Literal::Char(_, y)) => x.partial_cmp(&((y as i64) as f64)),
+            (&Literal::Char(_, x), &Literal::Char(_, y)) => x.partial_cmp(&y),
+            (&Literal::Char(_, x), &Literal::Integer(_, y)) => (x as i64).partial_cmp(&y),
+            (&Literal::Char(_, x), &Literal::BigInteger(_, ref y)) => (x as i64).partial_cmp(y),
+            (&Literal::Char(_, x), &Literal::Float(_, y)) => ((x as i64) as f64).partial_cmp(&y),
+        }
+    }
+}
+
+/// Maps can have two different types of field assignment:
+///
+/// * assoc - inserts or updates the given key with the given value
+/// * exact - updates the given key with the given value, or produces an error
+#[derive(Debug, Clone)]
+pub enum MapField {
+    Assoc {
+        span: ByteSpan,
+        key: Expr,
+        value: Expr,
+    },
+    Exact {
+        span: ByteSpan,
+        key: Expr,
+        value: Expr,
+    },
+}
+impl MapField {
+    pub fn key(&self) -> Expr {
+        match self {
+            &MapField::Assoc { ref key, .. } => key.clone(),
+            &MapField::Exact { ref key, .. } => key.clone(),
+        }
+    }
+
+    pub fn value(&self) -> Expr {
+        match self {
+            &MapField::Assoc { ref value, .. } => value.clone(),
+            &MapField::Exact { ref value, .. } => value.clone(),
+        }
+    }
+}
+impl PartialEq for MapField {
+    fn eq(&self, other: &Self) -> bool {
+        (self.key() == other.key()) && (self.value() == other.value())
+    }
+}
+impl PartialOrd for MapField {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match self.key().partial_cmp(&other.key()) {
+            None => None,
+            Some(Ordering::Equal) => self.value().partial_cmp(&other.value()),
+            Some(order) => Some(order),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Record {
+    pub span: ByteSpan,
+    pub name: Ident,
+    pub fields: Vec<RecordField>,
+}
+impl PartialEq for Record {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.fields == other.fields
+    }
+}
+
+// Accessing a record field value, e.g. Expr#myrec.field1
+#[derive(Debug, Clone)]
+pub struct RecordAccess {
+    pub span: ByteSpan,
+    pub record: Box<Expr>,
+    pub name: Ident,
+    pub field: Ident,
+}
+impl PartialEq for RecordAccess {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.field == other.field && self.record == other.record
+    }
+}
+
+// Referencing a record fields index, e.g. #myrec.field1
+#[derive(Debug, Clone)]
+pub struct RecordIndex {
+    pub span: ByteSpan,
+    pub name: Ident,
+    pub field: Ident,
+}
+impl PartialEq for RecordIndex {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.field == other.field
+    }
+}
+
+// Update a record field value, e.g. Expr#myrec.field1
+#[derive(Debug, Clone)]
+pub struct RecordUpdate {
+    pub span: ByteSpan,
+    pub record: Box<Expr>,
+    pub name: Ident,
+    pub updates: Vec<RecordField>,
+}
+impl PartialEq for RecordUpdate {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.record == other.record && self.updates == other.updates
+    }
+}
+
+/// Record fields always have a name, but both default value and type
+/// are optional in a record definition. When instantiating a record,
+/// if no value is given for a field, and no default is given,
+/// then `undefined` is the default.
+#[derive(Debug, Clone)]
+pub struct RecordField {
+    pub span: ByteSpan,
+    pub name: Name,
+    pub value: Option<Expr>,
+    pub ty: Option<Type>,
+}
+impl PartialEq for RecordField {
+    fn eq(&self, other: &Self) -> bool {
+        (self.name == other.name) && (self.value == other.value) && (self.ty == other.ty)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Binary {
+    pub span: ByteSpan,
+    pub elements: Vec<BinaryElement>,
+}
+impl PartialEq for Binary {
+    fn eq(&self, other: &Self) -> bool {
+        self.elements == other.elements
+    }
+}
+
+/// Used to represent a specific segment in a binary constructor, to
+/// produce a binary, all segments must be evaluated, and then assembled
+#[derive(Debug, Clone)]
+pub struct BinaryElement {
+    pub span: ByteSpan,
+    pub bit_expr: Expr,
+    pub bit_size: Option<Expr>,
+    pub bit_type: Option<Vec<BitType>>,
+}
+impl PartialEq for BinaryElement {
+    fn eq(&self, other: &Self) -> bool {
+        (self.bit_expr == other.bit_expr)
+            && (self.bit_size == other.bit_size)
+            && (self.bit_type == other.bit_type)
+    }
+}
+
+/// A bit type can come in the form `Type` or `Type:Size`
+#[derive(Debug, Clone)]
+pub enum BitType {
+    Name(ByteSpan, Ident),
+    Sized(ByteSpan, Ident, i64),
+}
+impl PartialEq for BitType {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (&BitType::Name(_, ref x1), &BitType::Name(_, ref y1)) => x1 == y1,
+            (&BitType::Sized(_, ref x1, ref x2), &BitType::Sized(_, ref y1, ref y2)) => {
+                (x1 == y1) && (x2 == y2)
+            }
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ListComprehension {
+    pub span: ByteSpan,
+    pub body: Box<Expr>,
+    pub qualifiers: Vec<Expr>,
+}
+impl PartialEq for ListComprehension {
+    fn eq(&self, other: &Self) -> bool {
+        self.body == other.body && self.qualifiers == other.qualifiers
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BinaryComprehension {
+    pub span: ByteSpan,
+    pub body: Box<Expr>,
+    pub qualifiers: Vec<Expr>,
+}
+impl PartialEq for BinaryComprehension {
+    fn eq(&self, other: &Self) -> bool {
+        self.body == other.body && self.qualifiers == other.qualifiers
+    }
+}
+
+// A generator of the form `LHS <- RHS`
+#[derive(Debug, Clone)]
+pub struct Generator {
+    pub span: ByteSpan,
+    pub pattern: Box<Expr>,
+    pub expr: Box<Expr>,
+}
+impl PartialEq for Generator {
+    fn eq(&self, other: &Self) -> bool {
+        self.pattern == other.pattern && self.expr == other.expr
+    }
+}
+
+// A generator of the form `LHS <= RHS`
+#[derive(Debug, Clone)]
+pub struct BinaryGenerator {
+    pub span: ByteSpan,
+    pub pattern: Box<Expr>,
+    pub expr: Box<Expr>,
+}
+impl PartialEq for BinaryGenerator {
+    fn eq(&self, other: &Self) -> bool {
+        self.pattern == other.pattern && self.expr == other.expr
+    }
+}
+
+// A sequence of expressions, e.g. begin expr1, .., exprN end
+#[derive(Debug, Clone)]
+pub struct Begin {
+    pub span: ByteSpan,
+    pub body: Vec<Expr>,
+}
+impl PartialEq for Begin {
+    fn eq(&self, other: &Self) -> bool {
+        self.body == other.body
+    }
+}
+
+// Function application, e.g. foo(expr1, .., exprN)
+#[derive(Debug, Clone)]
+pub struct Apply {
+    pub span: ByteSpan,
+    pub callee: Box<Expr>,
+    pub args: Vec<Expr>,
+}
+impl PartialEq for Apply {
+    fn eq(&self, other: &Self) -> bool {
+        self.callee == other.callee && self.args == other.args
+    }
+}
+
+// Remote, e.g. Foo:Bar
+#[derive(Debug, Clone)]
+pub struct Remote {
+    pub span: ByteSpan,
+    pub module: Box<Expr>,
+    pub function: Box<Expr>,
+}
+impl PartialEq for Remote {
+    fn eq(&self, other: &Self) -> bool {
+        self.module == other.module && self.function == other.function
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BinaryExpr {
+    pub span: ByteSpan,
+    pub lhs: Box<Expr>,
+    pub op: BinaryOp,
+    pub rhs: Box<Expr>,
+}
+impl PartialEq for BinaryExpr {
+    fn eq(&self, other: &Self) -> bool {
+        self.op == other.op && self.lhs == other.lhs && self.rhs == other.rhs
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UnaryExpr {
+    pub span: ByteSpan,
+    pub op: UnaryOp,
+    pub operand: Box<Expr>,
+}
+impl PartialEq for UnaryExpr {
+    fn eq(&self, other: &Self) -> bool {
+        self.op == other.op && self.operand == other.operand
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Match {
+    pub span: ByteSpan,
+    pub pattern: Box<Expr>,
+    pub expr: Box<Expr>,
+}
+impl PartialEq for Match {
+    fn eq(&self, other: &Self) -> bool {
+        self.pattern == other.pattern && self.expr == other.expr
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct If {
+    pub span: ByteSpan,
+    pub clauses: Vec<IfClause>,
+}
+impl PartialEq for If {
+    fn eq(&self, other: &Self) -> bool {
+        self.clauses == other.clauses
+    }
+}
+
+/// Represents a single clause in an `if` expression
+#[derive(Debug, Clone)]
+pub struct IfClause {
+    pub span: ByteSpan,
+    pub conditions: Vec<Expr>,
+    pub body: Vec<Expr>,
+}
+impl PartialEq for IfClause {
+    fn eq(&self, other: &Self) -> bool {
+        self.conditions == other.conditions && self.body == other.body
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Catch {
+    pub span: ByteSpan,
+    pub expr: Box<Expr>,
+}
+impl PartialEq for Catch {
+    fn eq(&self, other: &Self) -> bool {
+        self.expr == other.expr
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Case {
+    pub span: ByteSpan,
+    pub expr: Box<Expr>,
+    pub clauses: Vec<Clause>,
+}
+impl PartialEq for Case {
+    fn eq(&self, other: &Self) -> bool {
+        self.expr == other.expr && self.clauses == other.clauses
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Receive {
+    pub span: ByteSpan,
+    pub clauses: Option<Vec<Clause>>,
+    pub after: Option<After>,
+}
+impl PartialEq for Receive {
+    fn eq(&self, other: &Self) -> bool {
+        self.clauses == other.clauses && self.after == other.after
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Try {
+    pub span: ByteSpan,
+    pub exprs: Option<Vec<Expr>>,
+    pub clauses: Option<Vec<Clause>>,
+    pub catch_clauses: Option<Vec<TryClause>>,
+    pub after: Option<Vec<Expr>>,
+}
+impl PartialEq for Try {
+    fn eq(&self, other: &Self) -> bool {
+        self.exprs == other.exprs
+            && self.clauses == other.clauses
+            && self.catch_clauses == other.catch_clauses
+            && self.after == other.after
+    }
+}
+
+/// Represents a single `catch` clause in a `try` expression
+#[derive(Debug, Clone)]
+pub struct TryClause {
+    pub span: ByteSpan,
+    pub kind: Name,
+    pub error: Expr,
+    pub guard: Option<Vec<Guard>>,
+    pub trace: Ident,
+    pub body: Vec<Expr>,
+}
+impl PartialEq for TryClause {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+            && self.error == other.error
+            && self.guard == other.guard
+            && self.trace == other.trace
+            && self.body == other.body
+    }
+}
+
+/// Represents the `after` clause of a `receive` expression
+#[derive(Debug, Clone)]
+pub struct After {
+    pub span: ByteSpan,
+    pub timeout: Box<Expr>,
+    pub body: Vec<Expr>,
+}
+impl PartialEq for After {
+    fn eq(&self, other: &Self) -> bool {
+        self.timeout == other.timeout && self.body == other.body
+    }
+}
+
+/// Represents a single match clause in a `case`, `try`, or `receive` expression
+#[derive(Debug, Clone)]
+pub struct Clause {
+    pub span: ByteSpan,
+    pub pattern: Expr,
+    pub guard: Option<Vec<Guard>>,
+    pub body: Vec<Expr>,
+}
+impl PartialEq for Clause {
+    fn eq(&self, other: &Self) -> bool {
+        self.pattern == other.pattern && self.guard == other.guard && self.body == other.body
+    }
+}

--- a/frontend/src/parser/ast/functions.rs
+++ b/frontend/src/parser/ast/functions.rs
@@ -1,0 +1,471 @@
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+
+use diagnostics::{ByteSpan, Diagnostic, Label};
+
+use crate::preprocessor::PreprocessorError;
+
+use super::{Expr, Ident, Name, TypeSpec};
+use super::{ParseError, ParserError, TryParseResult};
+
+/// Represents a fully-resolved function name, with module/function/arity explicit
+#[derive(Debug, Clone)]
+pub struct ResolvedFunctionName {
+    pub span: ByteSpan,
+    pub module: Ident,
+    pub function: Ident,
+    pub arity: usize,
+}
+impl PartialEq for ResolvedFunctionName {
+    fn eq(&self, other: &Self) -> bool {
+        self.module == other.module && self.function == other.function && self.arity == other.arity
+    }
+}
+impl Eq for ResolvedFunctionName {}
+impl Hash for ResolvedFunctionName {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.module.hash(state);
+        self.function.hash(state);
+        self.arity.hash(state);
+    }
+}
+impl PartialOrd for ResolvedFunctionName {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let (xm, xf, xa) = (self.module, self.function, self.arity);
+        let (ym, yf, ya) = (other.module, other.function, other.arity);
+        match xm.partial_cmp(&ym) {
+            None | Some(Ordering::Equal) => match xf.partial_cmp(&yf) {
+                None | Some(Ordering::Equal) => xa.partial_cmp(&ya),
+                Some(order) => Some(order),
+            },
+            Some(order) => Some(order),
+        }
+    }
+}
+impl Ord for ResolvedFunctionName {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
+
+/// Represents a partially-resolved function name, not yet associated with a module
+/// This is typically used to express local captures, e.g. `fun do_stuff/0`
+#[derive(Debug, Clone)]
+pub struct PartiallyResolvedFunctionName {
+    pub span: ByteSpan,
+    pub function: Ident,
+    pub arity: usize,
+}
+impl PartiallyResolvedFunctionName {
+    pub fn resolve(&self, module: Ident) -> ResolvedFunctionName {
+        ResolvedFunctionName {
+            span: self.span.clone(),
+            module,
+            function: self.function.clone(),
+            arity: self.arity,
+        }
+    }
+}
+impl PartialEq for PartiallyResolvedFunctionName {
+    fn eq(&self, other: &Self) -> bool {
+        self.function == other.function && self.arity == other.arity
+    }
+}
+impl Eq for PartiallyResolvedFunctionName {}
+impl Hash for PartiallyResolvedFunctionName {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.function.hash(state);
+        self.arity.hash(state);
+    }
+}
+impl PartialOrd for PartiallyResolvedFunctionName {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let (xf, xa) = (self.function, self.arity);
+        let (yf, ya) = (other.function, other.arity);
+        match xf.partial_cmp(&yf) {
+            None | Some(Ordering::Equal) => xa.partial_cmp(&ya),
+            Some(order) => Some(order),
+        }
+    }
+}
+
+/// Represents a function name which contains parts which are not yet concrete,
+/// i.e. they are expressions which need to be evaluated to know precisely which
+/// module or function is referenced
+#[derive(Debug, Clone)]
+pub struct UnresolvedFunctionName {
+    pub span: ByteSpan,
+    pub module: Option<Name>,
+    pub function: Name,
+    pub arity: usize,
+}
+impl PartialEq for UnresolvedFunctionName {
+    fn eq(&self, other: &Self) -> bool {
+        self.module == other.module && self.function == other.function && self.arity == other.arity
+    }
+}
+impl Eq for UnresolvedFunctionName {}
+impl Hash for UnresolvedFunctionName {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.module.hash(state);
+        self.function.hash(state);
+        self.arity.hash(state);
+    }
+}
+impl PartialOrd for UnresolvedFunctionName {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match self.module.partial_cmp(&other.module) {
+            None | Some(Ordering::Equal) => match self.function.partial_cmp(&other.function) {
+                None | Some(Ordering::Equal) => self.arity.partial_cmp(&other.arity),
+                Some(order) => Some(order),
+            },
+            Some(order) => Some(order),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Hash)]
+pub enum FunctionName {
+    Resolved(ResolvedFunctionName),
+    PartiallyResolved(PartiallyResolvedFunctionName),
+    Unresolved(UnresolvedFunctionName),
+}
+impl FunctionName {
+    pub fn span(&self) -> ByteSpan {
+        match self {
+            &FunctionName::Resolved(ResolvedFunctionName { ref span, .. }) => span.clone(),
+            &FunctionName::PartiallyResolved(PartiallyResolvedFunctionName {
+                ref span, ..
+            }) => span.clone(),
+            &FunctionName::Unresolved(UnresolvedFunctionName { ref span, .. }) => span.clone(),
+        }
+    }
+
+    pub fn detect(span: ByteSpan, module: Option<Name>, function: Name, arity: usize) -> Self {
+        if module.is_none() {
+            return match function {
+                Name::Atom(f) => FunctionName::PartiallyResolved(PartiallyResolvedFunctionName {
+                    span,
+                    function: f,
+                    arity,
+                }),
+                Name::Var(_) => FunctionName::Unresolved(UnresolvedFunctionName {
+                    span,
+                    module: None,
+                    function,
+                    arity,
+                }),
+            };
+        }
+
+        if let Some(Name::Atom(m)) = module {
+            if let Name::Atom(f) = function {
+                return FunctionName::Resolved(ResolvedFunctionName {
+                    span,
+                    module: m,
+                    function: f,
+                    arity,
+                });
+            }
+        }
+
+        FunctionName::Unresolved(UnresolvedFunctionName {
+            span,
+            module,
+            function,
+            arity,
+        })
+    }
+
+    pub fn from_clause(clause: &FunctionClause) -> FunctionName {
+        match clause {
+            &FunctionClause {
+                name: Some(ref name),
+                ref span,
+                ref params,
+                ..
+            } => FunctionName::PartiallyResolved(PartiallyResolvedFunctionName {
+                span: span.clone(),
+                function: name.clone(),
+                arity: params.len(),
+            }),
+            _ => panic!("cannot create a FunctionName from an anonymous FunctionClause!"),
+        }
+    }
+}
+impl fmt::Display for FunctionName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            FunctionName::Resolved(ResolvedFunctionName {
+                ref module,
+                ref function,
+                arity,
+                ..
+            }) => write!(f, "{}:{}/{}", module, function, arity),
+            FunctionName::PartiallyResolved(PartiallyResolvedFunctionName {
+                ref function,
+                arity,
+                ..
+            }) => write!(f, "{}/{}", function, arity),
+            FunctionName::Unresolved(UnresolvedFunctionName {
+                module: Some(ref module),
+                ref function,
+                arity,
+                ..
+            }) => write!(f, "{:?}:{:?}/{}", module, function, arity),
+            FunctionName::Unresolved(UnresolvedFunctionName {
+                ref function,
+                arity,
+                ..
+            }) => write!(f, "{:?}/{}", function, arity),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NamedFunction {
+    pub span: ByteSpan,
+    pub name: Ident,
+    pub arity: usize,
+    pub clauses: Vec<FunctionClause>,
+    pub spec: Option<TypeSpec>,
+}
+impl PartialEq for NamedFunction {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.arity == other.arity
+            && self.clauses == other.clauses
+            && self.spec == other.spec
+    }
+}
+impl NamedFunction {
+    pub fn new(
+        errs: &mut Vec<ParseError>,
+        span: ByteSpan,
+        clauses: Vec<FunctionClause>,
+    ) -> TryParseResult<Self> {
+        debug_assert!(clauses.len() > 0);
+        let (head, rest) = clauses.split_first().unwrap();
+
+        if head.name.is_none() {
+            return Err(to_lalrpop_err!(PreprocessorError::Diagnostic(
+                Diagnostic::new_error("expected named function").with_label(
+                    Label::new_primary(head.span)
+                        .with_message("this clause has no name, but a name is required here")
+                )
+            )));
+        }
+
+        let head_span = &head.span;
+        let name = head.name.clone().unwrap();
+        let params = &head.params;
+        let arity = params.len();
+
+        // Check clauses
+        let mut last_clause = head_span.clone();
+        for clause in rest.iter() {
+            if clause.name.is_none() {
+                return Err(to_lalrpop_err!(PreprocessorError::Diagnostic(
+                    Diagnostic::new_error("expected named function clause")
+                        .with_label(
+                            Label::new_primary(clause.span).with_message(
+                                "this clause has no name, but a name is required here"
+                            )
+                        )
+                        .with_label(
+                            Label::new_secondary(last_clause).with_message(
+                                "expected a clause with the same name as this clause"
+                            )
+                        )
+                )));
+            }
+
+            let clause_span = &clause.span;
+            let clause_name = clause.name.clone().unwrap();
+            let clause_params = &clause.params;
+            let clause_arity = clause_params.len();
+
+            if clause_name != name {
+                errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                    Diagnostic::new_error("unterminated function clause")
+                        .with_label(Label::new_primary(last_clause.clone()).with_message(
+                            "this clause ends with ';', indicating that another clause follows"
+                        ))
+                        .with_label(
+                            Label::new_secondary(clause_span.clone())
+                                .with_message("but this clause has a different name")
+                        )
+                )));
+                continue;
+            }
+            if clause_arity != arity {
+                errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                    Diagnostic::new_error("unterminated function clause")
+                        .with_label(Label::new_primary(last_clause.clone()).with_message(
+                            "this clause ends with ';', indicating that another clause follows"
+                        ))
+                        .with_label(
+                            Label::new_secondary(clause_span.clone())
+                                .with_message("but this clause has a different arity")
+                        )
+                )));
+                continue;
+            }
+
+            last_clause = clause_span.clone();
+        }
+
+        Ok(NamedFunction {
+            span,
+            name: name.clone(),
+            arity,
+            clauses,
+            spec: None,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Lambda {
+    pub span: ByteSpan,
+    pub arity: usize,
+    pub clauses: Vec<FunctionClause>,
+}
+impl PartialEq for Lambda {
+    fn eq(&self, other: &Self) -> bool {
+        self.arity == other.arity && self.clauses == other.clauses
+    }
+}
+impl Lambda {
+    pub fn new(
+        errs: &mut Vec<ParseError>,
+        span: ByteSpan,
+        clauses: Vec<FunctionClause>,
+    ) -> TryParseResult<Self> {
+        debug_assert!(clauses.len() > 0);
+        let (head, rest) = clauses.split_first().unwrap();
+
+        let head_span = &head.span;
+        let params = &head.params;
+        let arity = params.len();
+
+        // Check clauses
+        let mut last_clause = head_span.clone();
+        for clause in rest.iter() {
+            let clause_span = &clause.span;
+            let clause_name = &clause.name;
+            let clause_params = &clause.params;
+            let clause_arity = clause_params.len();
+
+            if clause_name.is_some() {
+                return Err(to_lalrpop_err!(PreprocessorError::Diagnostic(
+                    Diagnostic::new_error("mismatched function clause")
+                        .with_label(
+                            Label::new_primary(clause_span.clone())
+                                .with_message("this clause is named")
+                        )
+                        .with_label(Label::new_secondary(last_clause.clone()).with_message(
+                            "but this clause is unnamed, all clauses must share the same name"
+                        ))
+                )));
+            }
+
+            if clause_arity != arity {
+                errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                    Diagnostic::new_error("mismatched function clause")
+                        .with_label(Label::new_primary(clause_span.clone()).with_message(
+                            "the arity of this clause does not match the previous clause"
+                        ))
+                        .with_label(
+                            Label::new_secondary(last_clause.clone())
+                                .with_message("this is the previous clause")
+                        )
+                )));
+                continue;
+            }
+
+            last_clause = clause_span.clone();
+        }
+
+        Ok(Lambda {
+            span,
+            arity,
+            clauses,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Function {
+    Named(NamedFunction),
+    Unnamed(Lambda),
+}
+impl Function {
+    pub fn span(&self) -> ByteSpan {
+        match self {
+            &Function::Named(NamedFunction { ref span, .. }) => span.clone(),
+            &Function::Unnamed(Lambda { ref span, .. }) => span.clone(),
+        }
+    }
+
+    pub fn new(
+        errs: &mut Vec<ParseError>,
+        span: ByteSpan,
+        clauses: Vec<FunctionClause>,
+    ) -> TryParseResult<Self> {
+        debug_assert!(clauses.len() > 0);
+        let (head, _rest) = clauses.split_first().unwrap();
+
+        if head.name.is_some() {
+            Ok(Function::Named(NamedFunction::new(errs, span, clauses)?))
+        } else {
+            Ok(Function::Unnamed(Lambda::new(errs, span, clauses)?))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FunctionClause {
+    pub span: ByteSpan,
+    pub name: Option<Ident>,
+    pub params: Vec<Expr>,
+    pub guard: Option<Vec<Guard>>,
+    pub body: Vec<Expr>,
+}
+impl PartialEq for FunctionClause {
+    fn eq(&self, other: &FunctionClause) -> bool {
+        self.name == other.name
+            && self.params == other.params
+            && self.guard == other.guard
+            && self.body == other.body
+    }
+}
+impl FunctionClause {
+    pub fn new(
+        span: ByteSpan,
+        name: Option<Ident>,
+        params: Vec<Expr>,
+        guard: Option<Vec<Guard>>,
+        body: Vec<Expr>,
+    ) -> Self {
+        FunctionClause {
+            span,
+            name,
+            params,
+            guard,
+            body,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Guard {
+    pub span: ByteSpan,
+    pub conditions: Vec<Expr>,
+}
+impl PartialEq for Guard {
+    fn eq(&self, other: &Guard) -> bool {
+        self.conditions == other.conditions
+    }
+}

--- a/frontend/src/parser/ast/module.rs
+++ b/frontend/src/parser/ast/module.rs
@@ -1,0 +1,960 @@
+use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
+use std::collections::{HashMap, HashSet};
+
+use diagnostics::{ByteSpan, Diagnostic, Label};
+
+use super::{Apply, Cons, Nil, Remote, Tuple};
+use super::{Attribute, Deprecation, UserAttribute};
+use super::{Callback, Record, TypeDef, TypeSig, TypeSpec};
+use super::{Expr, Ident, Literal, Symbol};
+use super::{FunctionClause, FunctionName, NamedFunction, ResolvedFunctionName};
+use super::{ParseError, ParserError};
+
+/// Represents expressions valid at the top level of a module body
+#[derive(Debug, Clone, PartialEq)]
+pub enum TopLevel {
+    Attribute(Attribute),
+    Record(Record),
+    Function(NamedFunction),
+}
+
+/// Represents a complete module, broken down into its constituent parts
+///
+/// Creating a module via `Module::new` ensures that each field is correctly
+/// populated, that sanity checking of the top-level constructs is performed,
+/// and that a module is ready for semantic analysis and lowering to IR
+///
+/// A key step performed by `Module::new` is decorating `ResolvedFunctionName`
+/// structs with the current module where appropriate (as this is currently not
+/// done during parsing, as the module is constructed last). This means that once
+/// constructed, one can use `ResolvedFunctionName` equality in sets/maps, which
+/// allows us to easily check definitions, usages, and more.
+#[derive(Debug, Clone)]
+pub struct Module {
+    pub span: ByteSpan,
+    pub name: Ident,
+    pub vsn: Option<Expr>,
+    pub compile: Option<CompileOptions>,
+    pub on_load: Option<ResolvedFunctionName>,
+    pub imports: HashSet<ResolvedFunctionName>,
+    pub exports: HashSet<ResolvedFunctionName>,
+    pub types: HashMap<ResolvedFunctionName, TypeDef>,
+    pub exported_types: HashSet<ResolvedFunctionName>,
+    pub behaviours: HashSet<Ident>,
+    pub callbacks: HashMap<ResolvedFunctionName, Callback>,
+    pub records: HashMap<Symbol, Record>,
+    pub attributes: HashMap<Ident, UserAttribute>,
+    pub functions: BTreeMap<ResolvedFunctionName, NamedFunction>,
+    // Used for module-level deprecation
+    pub deprecation: Option<Deprecation>,
+    // Used for function-level deprecation
+    pub deprecations: HashSet<Deprecation>,
+}
+impl Module {
+    /// Called by the parser to create the module once all of the top-level expressions have been
+    /// parsed, in other words this is the last function called when parsing a module.
+    ///
+    /// As a result, this function performs some initial linting of the module:
+    ///
+    /// * If configured to do so, warns if functions are missing type specs
+    /// * Warns about type specs for undefined functions
+    /// * Warns about redefined attributes
+    /// * Errors on invalid syntax in built-in attributes (e.g. -import(..))
+    /// * Errors on mismatched function clauses (name/arity)
+    /// * Errors on unterminated function clauses
+    /// * Errors on redefined functions
+    ///
+    /// And a few other similar lints
+    pub fn new(
+        errs: &mut Vec<ParseError>,
+        span: ByteSpan,
+        name: Ident,
+        mut body: Vec<TopLevel>,
+    ) -> Self {
+        let mut module = Module {
+            span,
+            name,
+            vsn: None,
+            on_load: None,
+            compile: None,
+            imports: HashSet::new(),
+            exports: HashSet::new(),
+            types: HashMap::new(),
+            exported_types: HashSet::new(),
+            behaviours: HashSet::new(),
+            callbacks: HashMap::new(),
+            records: HashMap::new(),
+            attributes: HashMap::new(),
+            functions: BTreeMap::new(),
+            deprecation: None,
+            deprecations: HashSet::new(),
+        };
+
+        // Functions will be decorated with their type specs as they are added
+        // to the module. To accomplish this, we keep track of seen type specs
+        // as they are defined, then later look up the spec for a function when
+        // a definition is encountered
+        let mut specs: HashMap<ResolvedFunctionName, TypeSpec> = HashMap::new();
+
+        // Walk every top-level expression and extend our initial module definition accordingly
+        for item in body.drain(..) {
+            match item {
+                TopLevel::Attribute(Attribute::Vsn(aspan, vsn)) => {
+                    if module.vsn.is_none() {
+                        module.vsn = Some(vsn);
+                        continue;
+                    }
+                    errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                        Diagnostic::new_error("attribute is already defined")
+                            .with_label(
+                                Label::new_primary(aspan).with_message("redefinition occurs here")
+                            )
+                            .with_label(
+                                Label::new_secondary(module.vsn.clone().map(|v| v.span()).unwrap())
+                                    .with_message("first defined here")
+                            )
+                    )));
+                }
+                TopLevel::Attribute(Attribute::OnLoad(aspan, fname)) => {
+                    if module.on_load.is_none() {
+                        let fname = fname.resolve(module.name.clone());
+                        module.on_load = Some(fname);
+                        continue;
+                    }
+                    errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                        Diagnostic::new_error("on_load can only be defined once")
+                            .with_label(
+                                Label::new_primary(aspan).with_message("redefinition occurs here")
+                            )
+                            .with_label(
+                                Label::new_secondary(
+                                    module.on_load.clone().map(|v| v.span).unwrap()
+                                )
+                                .with_message("first defined here")
+                            )
+                    )))
+                }
+                TopLevel::Attribute(Attribute::Import(aspan, from_module, mut imports)) => {
+                    for import in imports.drain(..) {
+                        let import = import.resolve(from_module.clone());
+                        match module.imports.get(&import) {
+                            None => {
+                                module.imports.insert(import);
+                            }
+                            Some(ResolvedFunctionName {
+                                span: ref prev_span,
+                                ..
+                            }) => {
+                                errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                                    Diagnostic::new_warning("unused import")
+                                        .with_label(Label::new_primary(aspan).with_message(
+                                            "this import is a duplicate of a previous import"
+                                        ))
+                                        .with_label(
+                                            Label::new_secondary(prev_span.clone())
+                                                .with_message("function was first imported here")
+                                        )
+                                )));
+                            }
+                        }
+                    }
+                }
+                TopLevel::Attribute(Attribute::Export(aspan, mut exports)) => {
+                    for export in exports.drain(..) {
+                        let export = export.resolve(module.name.clone());
+                        match module.exports.get(&export) {
+                            None => {
+                                module.exports.insert(export);
+                            }
+                            Some(ResolvedFunctionName {
+                                span: ref prev_span,
+                                ..
+                            }) => {
+                                errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                                    Diagnostic::new_warning("already exported")
+                                        .with_label(
+                                            Label::new_primary(aspan)
+                                                .with_message("duplicate export occurs here")
+                                        )
+                                        .with_label(
+                                            Label::new_secondary(prev_span.clone())
+                                                .with_message("function was first exported here")
+                                        )
+                                )));
+                            }
+                        }
+                    }
+                }
+                TopLevel::Attribute(Attribute::Type(ty)) => {
+                    let arity = ty.params.len();
+                    let type_name = ResolvedFunctionName {
+                        span: ty.name.span.clone(),
+                        module: module.name.clone(),
+                        function: ty.name.clone(),
+                        arity,
+                    };
+                    match module.types.get(&type_name) {
+                        None => {
+                            module.types.insert(type_name, ty);
+                        }
+                        Some(TypeDef {
+                            span: ref prev_span,
+                            ..
+                        }) => {
+                            errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                                Diagnostic::new_warning("type is already defined")
+                                    .with_label(
+                                        Label::new_primary(ty.span)
+                                            .with_message("redefinition occurs here")
+                                    )
+                                    .with_label(
+                                        Label::new_secondary(prev_span.clone())
+                                            .with_message("type was first defined here")
+                                    )
+                            )));
+                        }
+                    }
+                }
+                TopLevel::Attribute(Attribute::ExportType(aspan, mut exports)) => {
+                    for export in exports.drain(..) {
+                        let export = export.resolve(module.name.clone());
+                        match module.exported_types.get(&export) {
+                            None => {
+                                module.exported_types.insert(export);
+                            }
+                            Some(ResolvedFunctionName {
+                                span: ref prev_span,
+                                ..
+                            }) => {
+                                errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                                    Diagnostic::new_warning("type already exported")
+                                        .with_label(
+                                            Label::new_primary(aspan)
+                                                .with_message("duplicate export occurs here")
+                                        )
+                                        .with_label(
+                                            Label::new_secondary(prev_span.clone())
+                                                .with_message("type was first exported here")
+                                        )
+                                )));
+                            }
+                        }
+                    }
+                }
+                TopLevel::Attribute(Attribute::Behaviour(aspan, b_module)) => {
+                    match module.behaviours.get(&b_module) {
+                        None => {
+                            module.behaviours.insert(b_module);
+                        }
+                        Some(Ident {
+                            span: ref prev_span,
+                            ..
+                        }) => {
+                            errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                                Diagnostic::new_warning("duplicate behaviour declaration")
+                                    .with_label(
+                                        Label::new_primary(aspan)
+                                            .with_message("duplicate declaration occurs here")
+                                    )
+                                    .with_label(
+                                        Label::new_secondary(prev_span.clone())
+                                            .with_message("first declaration occurs here")
+                                    )
+                            )));
+                        }
+                    }
+                }
+                TopLevel::Attribute(Attribute::Callback(callback)) => {
+                    let first_sig = callback.sigs.first().unwrap();
+                    let arity = first_sig.params.len();
+
+                    // Verify that all clauses match
+                    if callback.sigs.len() > 1 {
+                        for TypeSig {
+                            span: ref sigspan,
+                            ref params,
+                            ..
+                        } in &callback.sigs[1..]
+                        {
+                            if params.len() != arity {
+                                errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                                    Diagnostic::new_error("mismatched arity")
+                                        .with_label(
+                                            Label::new_primary(sigspan.clone()).with_message(
+                                                format!("expected arity of {}", arity)
+                                            )
+                                        )
+                                        .with_label(
+                                            Label::new_secondary(first_sig.span.clone())
+                                                .with_message(
+                                                    "expected arity was derived from this clause"
+                                                )
+                                        )
+                                )));
+                            }
+                        }
+                    }
+                    // Check for redefinition
+                    let cb_name = ResolvedFunctionName {
+                        span: callback.span.clone(),
+                        module: module.name.clone(),
+                        function: callback.function.clone(),
+                        arity,
+                    };
+                    match module.callbacks.get(&cb_name) {
+                        None => {
+                            module.callbacks.insert(cb_name, callback);
+                            continue;
+                        }
+                        Some(Callback {
+                            span: ref prev_span,
+                            ..
+                        }) => {
+                            errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                                Diagnostic::new_error("cannot redefine callback")
+                                    .with_label(
+                                        Label::new_primary(callback.span)
+                                            .with_message("redefinition occurs here")
+                                    )
+                                    .with_label(
+                                        Label::new_secondary(prev_span.clone())
+                                            .with_message("callback first defined here")
+                                    )
+                            )));
+                        }
+                    }
+                }
+                TopLevel::Attribute(Attribute::Spec(typespec)) => {
+                    let first_sig = typespec.sigs.first().unwrap();
+                    let arity = first_sig.params.len();
+
+                    // Verify that all clauses match
+                    if typespec.sigs.len() > 1 {
+                        for TypeSig {
+                            span: ref sigspan,
+                            ref params,
+                            ..
+                        } in &typespec.sigs[1..]
+                        {
+                            if params.len() != arity {
+                                errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                                    Diagnostic::new_error("mismatched arity")
+                                        .with_label(
+                                            Label::new_primary(sigspan.clone()).with_message(
+                                                format!("expected arity of {}", arity)
+                                            )
+                                        )
+                                        .with_label(
+                                            Label::new_secondary(first_sig.span.clone())
+                                                .with_message(
+                                                    "expected arity was derived from this clause"
+                                                )
+                                        )
+                                )));
+                            }
+                        }
+                    }
+                    // Check for redefinition
+                    let spec_name = ResolvedFunctionName {
+                        span: typespec.span.clone(),
+                        module: module.name.clone(),
+                        function: typespec.function.clone(),
+                        arity,
+                    };
+                    match specs.get(&spec_name) {
+                        None => {
+                            specs.insert(spec_name.clone(), typespec);
+                        }
+                        Some(TypeSpec {
+                            span: ref prev_span,
+                            ..
+                        }) => {
+                            errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                                Diagnostic::new_error("spec already defined")
+                                    .with_label(
+                                        Label::new_primary(typespec.span)
+                                            .with_message("redefinition occurs here")
+                                    )
+                                    .with_label(
+                                        Label::new_secondary(prev_span.clone())
+                                            .with_message("spec first defined here")
+                                    )
+                            )));
+                        }
+                    }
+                }
+                TopLevel::Attribute(Attribute::Compile(_, compile)) => match module.compile {
+                    None => {
+                        let (opts, mut validation_errs) =
+                            CompileOptions::from_expr(&module.name, &compile);
+                        module.compile = Some(opts);
+                        for err in validation_errs.drain(..) {
+                            errs.push(to_lalrpop_err!(ParserError::Diagnostic(err)));
+                        }
+                        continue;
+                    }
+                    Some(ref mut opts) => {
+                        if let Err(mut validation_errs) =
+                            opts.merge_from_expr(&module.name, &compile)
+                        {
+                            for err in validation_errs.drain(..) {
+                                errs.push(to_lalrpop_err!(ParserError::Diagnostic(err)));
+                            }
+                        }
+                    }
+                },
+                TopLevel::Attribute(Attribute::Deprecation(mut deprecations)) => {
+                    for deprecation in deprecations.drain(..) {
+                        match deprecation {
+                            Deprecation::Module {
+                                span: ref dspan, ..
+                            } => match module.deprecation {
+                                None => {
+                                    module.deprecation = Some(deprecation);
+                                }
+                                Some(Deprecation::Module {
+                                    span: ref orig_span,
+                                    ..
+                                }) => {
+                                    errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                                            Diagnostic::new_warning("redundant deprecation")
+                                                .with_label(Label::new_primary(dspan.clone())
+                                                    .with_message("this module is already deprecated by a previous declaration"))
+                                                .with_label(Label::new_secondary(orig_span.clone())
+                                                    .with_message("deprecation first declared here"))
+                                        )));
+                                }
+                                Some(Deprecation::Function { .. }) => unreachable!(),
+                            },
+                            Deprecation::Function {
+                                span: ref fspan, ..
+                            } => {
+                                if let Some(Deprecation::Module {
+                                    span: ref mspan, ..
+                                }) = module.deprecation
+                                {
+                                    errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                                        Diagnostic::new_warning("redundant deprecation")
+                                            .with_label(Label::new_primary(*fspan)
+                                                .with_message("module is deprecated, so deprecating functions is redundant"))
+                                            .with_label(Label::new_secondary(mspan.clone())
+                                                .with_message("module deprecation occurs here"))
+                                    )));
+                                    continue;
+                                }
+
+                                match module.deprecations.get(&deprecation) {
+                                    None => {
+                                        module.deprecations.insert(deprecation);
+                                    }
+                                    Some(Deprecation::Function {
+                                        span: ref prev_span,
+                                        ..
+                                    }) => {
+                                        errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                                            Diagnostic::new_warning("redundant deprecation")
+                                                .with_label(Label::new_primary(*fspan)
+                                                    .with_message("this function is already deprecated by a previous declaration"))
+                                                .with_label(Label::new_secondary(prev_span.clone())
+                                                    .with_message("deprecation first declared here"))
+                                        )));
+                                    }
+                                    Some(Deprecation::Module { .. }) => unreachable!(),
+                                }
+                            }
+                        }
+                    }
+                }
+                TopLevel::Attribute(Attribute::Custom(attr)) => {
+                    match attr.name.name.as_str().get() {
+                        "module" => {
+                            errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                                Diagnostic::new_error("multiple module declarations")
+                                    .with_label(
+                                        Label::new_primary(attr.span.clone())
+                                            .with_message("invalid declaration occurs here")
+                                    )
+                                    .with_label(
+                                        Label::new_secondary(module.name.span.clone())
+                                            .with_message("module first declared here")
+                                    )
+                            )));
+                            continue;
+                        }
+                        "dialyzer" => {
+                            // Drop dialyzer attributes as they are unused
+                            continue;
+                        }
+                        _ => (),
+                    }
+                    match module.attributes.get(&attr.name) {
+                        None => {
+                            module.attributes.insert(attr.name.clone(), attr);
+                        }
+                        Some(UserAttribute {
+                            span: ref prev_span,
+                            ..
+                        }) => {
+                            errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                                Diagnostic::new_warning("redefined attribute")
+                                    .with_label(
+                                        Label::new_primary(attr.span.clone())
+                                            .with_message("redefinition occurs here")
+                                    )
+                                    .with_label(
+                                        Label::new_secondary(prev_span.clone())
+                                            .with_message("previously defined here")
+                                    )
+                            )));
+                            module.attributes.insert(attr.name.clone(), attr);
+                        }
+                    }
+                }
+                TopLevel::Record(record) => {
+                    // TODO: Normalize records so that all fields have explicit initializers
+                    //   * Use `undefined` for fields that have no default value
+                    // TODO: Check for duplicate fields
+                    let name = record.name.name.clone();
+                    match module.records.get(&name) {
+                        None => {
+                            module.records.insert(name, record);
+                        }
+                        Some(Record {
+                            span: ref prev_span,
+                            ..
+                        }) => {
+                            errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                                Diagnostic::new_error("record already defined")
+                                    .with_label(
+                                        Label::new_primary(record.span.clone())
+                                            .with_message("duplicate definition occurs here")
+                                    )
+                                    .with_label(
+                                        Label::new_secondary(prev_span.clone())
+                                            .with_message("previously defined here")
+                                    )
+                            )));
+                        }
+                    }
+                }
+                TopLevel::Function(mut function @ NamedFunction { .. }) => {
+                    let name = &function.name;
+                    let resolved_name = ResolvedFunctionName {
+                        span: name.span.clone(),
+                        module: module.name.clone(),
+                        function: name.clone(),
+                        arity: function.arity,
+                    };
+                    let warn_missing_specs = module
+                        .compile
+                        .as_ref()
+                        .map(|c| c.warn_missing_spec)
+                        .unwrap_or(false);
+                    function.spec = match specs.get(&resolved_name) {
+                        None if warn_missing_specs => {
+                            errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                                Diagnostic::new_warning("missing function spec").with_label(
+                                    Label::new_primary(function.span.clone())
+                                        .with_message("expected type spec for this function")
+                                )
+                            )));
+                            None
+                        }
+                        None => None,
+                        Some(spec) => Some(spec.clone()),
+                    };
+                    match module.functions.entry(resolved_name) {
+                        Entry::Vacant(f) => {
+                            f.insert(function);
+                        }
+                        Entry::Occupied(initial_def) => {
+                            let def = initial_def.into_mut();
+                            errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                                Diagnostic::new_error(
+                                    "clauses from the same function should be grouped together"
+                                )
+                                .with_label(
+                                    Label::new_primary(function.span.clone())
+                                        .with_message("found more clauses here")
+                                )
+                                .with_label(
+                                    Label::new_secondary(def.span.clone())
+                                        .with_message("function is first defined here")
+                                )
+                            )));
+                            def.clauses.append(&mut function.clauses);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Ensure internal pseudo-locals are defined
+        module.define_pseudolocals();
+
+        // Verify on_load function exists
+        if let Some(ref on_load_name) = module.on_load {
+            if !module.functions.contains_key(on_load_name) {
+                errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                    Diagnostic::new_error("invalid on_load function").with_label(
+                        Label::new_primary(on_load_name.span.clone())
+                            .with_message("this function is not defined in this module")
+                    )
+                )));
+            }
+        }
+
+        // Check for orphaned type specs
+        for (spec_name, spec) in &specs {
+            if !module.functions.contains_key(spec_name) {
+                errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                    Diagnostic::new_warning("type spec for undefined function").with_label(
+                        Label::new_primary(spec.span.clone()).with_message(
+                            "this type spec has no corresponding function definition"
+                        )
+                    )
+                )));
+            }
+        }
+
+        module
+    }
+
+    // Every module in Erlang has some functions implicitly defined for internal use:
+    //
+    // * `module_info/0` (exported)
+    // * `module_info/1` (exported)
+    // * `record_info/2`
+    // * `behaviour_info/1` (optional)
+    fn define_pseudolocals(&mut self) {
+        let mod_info_0 = fun!(module_info () ->
+            apply!(remote!(erlang, get_module_info), Expr::Literal(Literal::Atom(self.name.clone())))
+        );
+        let mod_info_1 = fun!(module_info (Key) ->
+            apply!(remote!(erlang, get_module_info), Expr::Literal(Literal::Atom(self.name.clone())), var!(Key))
+        );
+
+        self.define_function(mod_info_0);
+        self.define_function(mod_info_1);
+
+        if self.callbacks.len() > 0 {
+            let callbacks = self.callbacks.iter().fold(nil!(), |acc, (cbname, cb)| {
+                if cb.optional {
+                    acc
+                } else {
+                    cons!(
+                        tuple!(
+                            atom_from_sym!(cbname.function.name.clone()),
+                            int!(cbname.arity as i64)
+                        ),
+                        acc
+                    )
+                }
+            });
+            let opt_callbacks = self.callbacks.iter().fold(nil!(), |acc, (cbname, cb)| {
+                if cb.optional {
+                    cons!(
+                        tuple!(
+                            atom_from_sym!(cbname.function.name.clone()),
+                            int!(cbname.arity as i64)
+                        ),
+                        acc
+                    )
+                } else {
+                    acc
+                }
+            });
+
+            let behaviour_info_1 = fun!(behaviour_info
+                                        (atom!(callbacks)) -> callbacks;
+                                        (atom!(optional_callbacks)) -> opt_callbacks);
+
+            self.define_function(behaviour_info_1);
+        }
+    }
+
+    fn define_function(&mut self, f: NamedFunction) {
+        let name = ResolvedFunctionName {
+            span: f.span.clone(),
+            module: self.name.clone(),
+            function: f.name.clone(),
+            arity: f.arity,
+        };
+        self.functions.insert(name, f);
+    }
+}
+impl PartialEq for Module {
+    fn eq(&self, other: &Module) -> bool {
+        if self.name != other.name {
+            return false;
+        }
+        if self.vsn != other.vsn {
+            return false;
+        }
+        if self.on_load != other.on_load {
+            return false;
+        }
+        if self.imports != other.imports {
+            return false;
+        }
+        if self.exports != other.exports {
+            return false;
+        }
+        if self.types != other.types {
+            return false;
+        }
+        if self.exported_types != other.exported_types {
+            return false;
+        }
+        if self.behaviours != other.behaviours {
+            return false;
+        }
+        if self.callbacks != other.callbacks {
+            return false;
+        }
+        if self.records != other.records {
+            return false;
+        }
+        if self.attributes != other.attributes {
+            return false;
+        }
+        if self.functions != other.functions {
+            return false;
+        }
+        true
+    }
+}
+
+/// This structure holds all module-specific compiler options
+/// and configuration; it is passed through all phases of
+/// compilation and is a superset of options in CompilerSettings
+/// where applicable
+#[derive(Debug, Clone)]
+pub struct CompileOptions {
+    // Same as erlc, prints informational warnings about
+    // binary matching optimizations
+    pub compile_info: HashMap<Symbol, Expr>,
+    // Used to override the filename used in errors/warnings
+    pub file: Option<String>,
+    // Treats all warnings as errors
+    pub warnings_as_errors: bool,
+    // Disables warnings
+    pub no_warn: bool,
+    // Exports all functions
+    pub export_all: bool,
+    // Prevents auto importing any functions
+    pub no_auto_import: bool,
+    // Prevents auto importing the specified functions
+    pub no_auto_imports: HashSet<ResolvedFunctionName>,
+    // Warns if export_all is used
+    pub warn_export_all: bool,
+    // Warns when exported variables are used
+    pub warn_export_vars: bool,
+    // Warns when variables are shadowed
+    pub warn_shadow_vars: bool,
+    // Warns when a function is unused
+    pub warn_unused_function: bool,
+    // Disables the unused function warning for the specified functions
+    pub no_warn_unused_functions: HashSet<ResolvedFunctionName>,
+    // Warns about unused imports
+    pub warn_unused_import: bool,
+    // Warns about unused variables
+    pub warn_unused_var: bool,
+    // Warns about unused records
+    pub warn_unused_record: bool,
+    // Warns about missing type specs
+    pub warn_missing_spec: bool,
+}
+impl Default for CompileOptions {
+    fn default() -> Self {
+        CompileOptions {
+            compile_info: HashMap::new(),
+            file: None,
+            warnings_as_errors: false,
+            no_warn: false,
+            export_all: false,
+            no_auto_import: false,
+            no_auto_imports: HashSet::new(),
+            warn_export_all: true,
+            warn_export_vars: true,
+            warn_shadow_vars: true,
+            warn_unused_function: true,
+            no_warn_unused_functions: HashSet::new(),
+            warn_unused_import: true,
+            warn_unused_var: true,
+            warn_unused_record: true,
+            warn_missing_spec: false,
+        }
+    }
+}
+impl CompileOptions {
+    pub fn from_expr(module: &Ident, expr: &Expr) -> (Self, Vec<Diagnostic>) {
+        let mut opts = CompileOptions::default();
+        match opts.merge_from_expr(module, expr) {
+            Ok(_) => (opts, Vec::new()),
+            Err(errs) => (opts, errs),
+        }
+    }
+
+    pub fn merge_from_expr(&mut self, module: &Ident, expr: &Expr) -> Result<(), Vec<Diagnostic>> {
+        self.set_option(module, expr)
+    }
+
+    fn set_option(&mut self, module: &Ident, expr: &Expr) -> Result<(), Vec<Diagnostic>> {
+        let mut diagnostics = Vec::new();
+        match expr {
+            // e.g. -compile(export_all).
+            &Expr::Literal(Literal::Atom(ref option_name)) => match option_name.as_str().get() {
+                "export_all" => self.export_all = true,
+                "nowarn_export_all" => self.warn_export_all = false,
+                "nowarn_shadow_vars" => self.warn_shadow_vars = false,
+                "nowarn_unused_function" => self.warn_unused_function = false,
+                "nowarn_unused_vars" => self.warn_unused_var = false,
+                "no_auto_import" => self.no_auto_import = true,
+                _name => {
+                    diagnostics.push(
+                        Diagnostic::new_warning("invalid compile option").with_label(
+                            Label::new_primary(option_name.span)
+                                .with_message("this option is either unsupported or unrecognized"),
+                        ),
+                    );
+                }
+            },
+            // e.g. -compile([export_all, nowarn_unused_function]).
+            &Expr::Cons(Cons {
+                ref head, ref tail, ..
+            }) => self.compiler_opts_from_list(&mut diagnostics, module, to_list(head, tail)),
+            // e.g. -compile({nowarn_unused_function, [some_fun/0]}).
+            &Expr::Tuple(Tuple { ref elements, .. }) => {
+                if let Some((head, tail)) = elements.split_first() {
+                    if let &Expr::Literal(Literal::Atom(ref option_name)) = head {
+                        match option_name.as_str().get() {
+                            "no_auto_import" => {
+                                self.no_auto_imports(&mut diagnostics, module, tail);
+                            }
+                            "nowarn_unused_function" => {
+                                self.no_warn_unused_functions(&mut diagnostics, module, tail);
+                            }
+                            _name => {
+                                diagnostics.push(
+                                    Diagnostic::new_warning("invalid compile option").with_label(
+                                        Label::new_primary(option_name.span).with_message(
+                                            "this option is either unsupported or unrecognized",
+                                        ),
+                                    ),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            term => {
+                diagnostics.push(
+                    Diagnostic::new_warning("invalid compile option").with_label(
+                        Label::new_primary(term.span())
+                            .with_message("unexpected expression: expected atom, list, or tuple"),
+                    ),
+                );
+            }
+        }
+
+        if diagnostics.len() > 0 {
+            return Err(diagnostics);
+        }
+
+        Ok(())
+    }
+
+    fn compiler_opts_from_list(
+        &mut self,
+        diagnostics: &mut Vec<Diagnostic>,
+        module: &Ident,
+        options: Vec<Expr>,
+    ) {
+        for option in options {
+            match self.set_option(module, &option) {
+                Ok(_) => continue,
+                Err(mut diags) => diagnostics.append(&mut diags),
+            }
+        }
+    }
+
+    fn no_auto_imports(
+        &mut self,
+        diagnostics: &mut Vec<Diagnostic>,
+        module: &Ident,
+        imports: &[Expr],
+    ) {
+        for import in imports {
+            match import {
+                Expr::FunctionName(FunctionName::PartiallyResolved(name)) => {
+                    self.no_auto_imports.insert(name.resolve(module.clone()));
+                }
+                other => {
+                    diagnostics.push(
+                        Diagnostic::new_warning("invalid compile option").with_label(
+                            Label::new_primary(other.span()).with_message(
+                                "expected function name/arity term for no_auto_imports",
+                            ),
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
+    fn no_warn_unused_functions(
+        &mut self,
+        diagnostics: &mut Vec<Diagnostic>,
+        module: &Ident,
+        funs: &[Expr],
+    ) {
+        for fun in funs {
+            match fun {
+                Expr::FunctionName(FunctionName::PartiallyResolved(name)) => {
+                    self.no_warn_unused_functions
+                        .insert(name.resolve(module.clone()));
+                }
+                other => {
+                    diagnostics.push(
+                        Diagnostic::new_warning("invalid compile option").with_label(
+                            Label::new_primary(other.span()).with_message(
+                                "expected function name/arity term for no_warn_unused_functions",
+                            ),
+                        ),
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn to_list(head: &Expr, tail: &Expr) -> Vec<Expr> {
+    let mut list = Vec::new();
+    match head {
+        &Expr::Cons(Cons {
+            head: ref head2,
+            tail: ref tail2,
+            ..
+        }) => {
+            let mut h = to_list(head2, tail2);
+            list.append(&mut h);
+        }
+        expr => list.push(expr.clone()),
+    }
+    match tail {
+        &Expr::Cons(Cons {
+            head: ref head2,
+            tail: ref tail2,
+            ..
+        }) => {
+            let mut t = to_list(head2, tail2);
+            list.append(&mut t);
+        }
+        &Expr::Nil(_) => (),
+        expr => list.push(expr.clone()),
+    }
+
+    list
+}

--- a/frontend/src/parser/ast/types.rs
+++ b/frontend/src/parser/ast/types.rs
@@ -1,0 +1,283 @@
+use std::collections::HashSet;
+
+use lazy_static::lazy_static;
+
+use diagnostics::ByteSpan;
+
+use super::{BinaryOp, UnaryOp};
+use super::{Ident, Name, Symbol};
+
+lazy_static! {
+    pub static ref BUILTIN_TYPES: HashSet<(Symbol, usize)> = {
+        let mut bts = HashSet::new();
+        bts.insert((Symbol::intern("any"), 0));
+        bts.insert((Symbol::intern("arity"), 0));
+        bts.insert((Symbol::intern("atom"), 0));
+        bts.insert((Symbol::intern("binary"), 0));
+        bts.insert((Symbol::intern("bitstring"), 0));
+        bts.insert((Symbol::intern("bool"), 0));
+        bts.insert((Symbol::intern("boolean"), 0));
+        bts.insert((Symbol::intern("byte"), 0));
+        bts.insert((Symbol::intern("char"), 0));
+        bts.insert((Symbol::intern("float"), 0));
+        bts.insert((Symbol::intern("function"), 0));
+        bts.insert((Symbol::intern("identifier"), 0));
+        bts.insert((Symbol::intern("integer"), 0));
+        bts.insert((Symbol::intern("iodata"), 0));
+        bts.insert((Symbol::intern("iolist"), 0));
+        bts.insert((Symbol::intern("list"), 0));
+        bts.insert((Symbol::intern("list"), 1));
+        bts.insert((Symbol::intern("map"), 0));
+        bts.insert((Symbol::intern("maybe_improper_list"), 0));
+        bts.insert((Symbol::intern("maybe_improper_list"), 2));
+        bts.insert((Symbol::intern("mfa"), 0));
+        bts.insert((Symbol::intern("module"), 0));
+        bts.insert((Symbol::intern("neg_integer"), 0));
+        bts.insert((Symbol::intern("nil"), 0));
+        bts.insert((Symbol::intern("no_return"), 0));
+        bts.insert((Symbol::intern("node"), 0));
+        bts.insert((Symbol::intern("non_neg_integer"), 0));
+        bts.insert((Symbol::intern("none"), 0));
+        bts.insert((Symbol::intern("nonempty_improper_list"), 2));
+        bts.insert((Symbol::intern("nonempty_list"), 0));
+        bts.insert((Symbol::intern("nonempty_list"), 1));
+        bts.insert((Symbol::intern("nonempty_maybe_improper_list"), 0));
+        bts.insert((Symbol::intern("nonempty_maybe_improper_list"), 2));
+        bts.insert((Symbol::intern("nonempty_string"), 0));
+        bts.insert((Symbol::intern("number"), 0));
+        bts.insert((Symbol::intern("pid"), 0));
+        bts.insert((Symbol::intern("port"), 0));
+        bts.insert((Symbol::intern("pos_integer"), 0));
+        bts.insert((Symbol::intern("reference"), 0));
+        bts.insert((Symbol::intern("string"), 0));
+        bts.insert((Symbol::intern("term"), 0));
+        bts.insert((Symbol::intern("timeout"), 0));
+        bts.insert((Symbol::intern("tuple"), 0));
+        bts
+    };
+}
+
+#[derive(Debug, Clone)]
+pub enum Type {
+    Name(Name),
+    Annotated {
+        span: ByteSpan,
+        name: Ident,
+        ty: Box<Type>,
+    },
+    Union {
+        span: ByteSpan,
+        types: Vec<Type>,
+    },
+    Range {
+        span: ByteSpan,
+        start: Box<Type>,
+        end: Box<Type>,
+    },
+    BinaryOp {
+        span: ByteSpan,
+        lhs: Box<Type>,
+        op: BinaryOp,
+        rhs: Box<Type>,
+    },
+    UnaryOp {
+        span: ByteSpan,
+        op: UnaryOp,
+        rhs: Box<Type>,
+    },
+    Generic {
+        span: ByteSpan,
+        fun: Ident,
+        params: Vec<Type>,
+    },
+    Remote {
+        span: ByteSpan,
+        module: Ident,
+        fun: Ident,
+        args: Vec<Type>,
+    },
+    Nil(ByteSpan),
+    List(ByteSpan, Box<Type>),
+    NonEmptyList(ByteSpan, Box<Type>),
+    Map(ByteSpan, Vec<Type>),
+    Tuple(ByteSpan, Vec<Type>),
+    Record(ByteSpan, Ident, Vec<Type>),
+    Binary(ByteSpan, i64, i64),
+    Integer(ByteSpan, i64),
+    Char(ByteSpan, char),
+    AnyFun(ByteSpan),
+    Fun {
+        span: ByteSpan,
+        params: Vec<Type>,
+        ret: Box<Type>,
+    },
+    KeyValuePair(ByteSpan, Box<Type>, Box<Type>),
+    Field(ByteSpan, Ident, Box<Type>),
+}
+impl Type {
+    pub fn union(span: ByteSpan, lhs: Type, rhs: Type) -> Self {
+        let mut types = match lhs {
+            Type::Union { types, .. } => types,
+            ty => vec![ty],
+        };
+        let mut rest = match rhs {
+            Type::Union { types, .. } => types,
+            ty => vec![ty],
+        };
+        types.append(&mut rest);
+        Type::Union { span, types }
+    }
+
+    pub fn is_builtin_type(&self) -> bool {
+        match self {
+            &Type::Name(Name::Atom(Ident { ref name, .. })) => BUILTIN_TYPES.contains(&(*name, 0)),
+            &Type::Annotated { ref name, .. } => BUILTIN_TYPES.contains(&(name.name, 0)),
+            &Type::Generic {
+                ref fun,
+                ref params,
+                ..
+            } => BUILTIN_TYPES.contains(&(fun.name, params.len())),
+            &Type::Nil(_) => true,
+            &Type::List(_, _) => true,
+            &Type::NonEmptyList(_, _) => true,
+            &Type::Map(_, _) => true,
+            &Type::Tuple(_, _) => true,
+            &Type::Record(_, _, _) => true,
+            &Type::Binary(_, _, _) => true,
+            &Type::Integer(_, _) => true,
+            &Type::Char(_, _) => true,
+            &Type::AnyFun(_) => true,
+            &Type::Fun { .. } => true,
+            &Type::KeyValuePair(_, _, _) => true,
+            &Type::Field(_, _, _) => true,
+            _ => false,
+        }
+    }
+}
+impl PartialEq for Type {
+    fn eq(&self, other: &Type) -> bool {
+        let left = std::mem::discriminant(self);
+        let right = std::mem::discriminant(other);
+        if left != right {
+            return false;
+        }
+
+        match (self, other) {
+            (
+                &Type::Annotated {
+                    name: ref x1,
+                    ty: ref x2,
+                    ..
+                },
+                &Type::Annotated {
+                    name: ref y1,
+                    ty: ref y2,
+                    ..
+                },
+            ) => (x1 == y1) && (x2 == y2),
+            (
+                &Type::Union {
+                    types: ref types1, ..
+                },
+                &Type::Union {
+                    types: ref types2, ..
+                },
+            ) => types1 == types2,
+            (
+                &Type::Range {
+                    start: ref x1,
+                    end: ref x2,
+                    ..
+                },
+                &Type::Range {
+                    start: ref y1,
+                    end: ref y2,
+                    ..
+                },
+            ) => (x1 == y1) && (x2 == y2),
+            (
+                &Type::BinaryOp {
+                    lhs: ref x1,
+                    op: ref x2,
+                    rhs: ref x3,
+                    ..
+                },
+                &Type::BinaryOp {
+                    lhs: ref y1,
+                    op: ref y2,
+                    rhs: ref y3,
+                    ..
+                },
+            ) => (x1 == y1) && (x2 == y2) && (x3 == y3),
+            (
+                &Type::UnaryOp {
+                    op: ref x1,
+                    rhs: ref x2,
+                    ..
+                },
+                &Type::UnaryOp {
+                    op: ref y1,
+                    rhs: ref y2,
+                    ..
+                },
+            ) => (x1 == y1) && (x2 == y2),
+            (
+                &Type::Generic {
+                    fun: ref x1,
+                    params: ref x2,
+                    ..
+                },
+                &Type::Generic {
+                    fun: ref y1,
+                    params: ref y2,
+                    ..
+                },
+            ) => (x1 == y1) && (x2 == y2),
+            (
+                &Type::Remote {
+                    module: ref x1,
+                    fun: ref x2,
+                    args: ref x3,
+                    ..
+                },
+                &Type::Remote {
+                    module: ref y1,
+                    fun: ref y2,
+                    args: ref y3,
+                    ..
+                },
+            ) => (x1 == y1) && (x2 == y2) && (x3 == y3),
+            (&Type::Nil(_), &Type::Nil(_)) => true,
+            (&Type::List(_, ref x), &Type::List(_, ref y)) => x == y,
+            (&Type::NonEmptyList(_, ref x), &Type::List(_, ref y)) => x == y,
+            (&Type::Map(_, ref x), &Type::Map(_, ref y)) => x == y,
+            (&Type::Tuple(_, ref x), &Type::Tuple(_, ref y)) => x == y,
+            (&Type::Record(_, ref x1, ref x2), &Type::Record(_, ref y1, ref y2)) => {
+                (x1 == y1) && (x2 == y2)
+            }
+            (&Type::Binary(_, m1, n1), &Type::Binary(_, m2, n2)) => (m1 == m2) && (n1 == n2),
+            (&Type::Integer(_, x), &Type::Integer(_, y)) => x == y,
+            (&Type::Char(_, x), &Type::Char(_, y)) => x == y,
+            (&Type::AnyFun(_), &Type::AnyFun(_)) => true,
+            (
+                &Type::Fun {
+                    params: ref x1,
+                    ret: ref x2,
+                    ..
+                },
+                &Type::Fun {
+                    params: ref y1,
+                    ret: ref y2,
+                    ..
+                },
+            ) => (x1 == y1) && (x2 == y2),
+            (&Type::KeyValuePair(_, ref x1, ref x2), &Type::KeyValuePair(_, ref y1, ref y2)) => {
+                (x1 == y1) && (x2 == y2)
+            }
+            (&Type::Field(_, ref x1, ref x2), &Type::Field(_, ref y1, ref y2)) => {
+                (x1 == y1) && (x2 == y2)
+            }
+            _ => false,
+        }
+    }
+}

--- a/frontend/src/parser/errors.rs
+++ b/frontend/src/parser/errors.rs
@@ -1,0 +1,111 @@
+use std::convert::From;
+
+use diagnostics::{ByteIndex, ByteSpan, Diagnostic, Label};
+use failure::Fail;
+
+use crate::lexer::{SourceError, Token};
+use crate::preprocessor::PreprocessorError;
+
+pub type ParseError = lalrpop_util::ParseError<ByteIndex, Token, ParserError>;
+
+#[derive(Fail, Debug)]
+pub enum ParserError {
+    #[fail(display = "{}", _0)]
+    Preprocessor(#[fail(cause)] PreprocessorError),
+
+    #[fail(display = "{}", _0)]
+    Source(#[fail(cause)] SourceError),
+
+    #[fail(display = "i/o error")]
+    IO(#[fail(cause)] std::io::Error),
+
+    #[fail(display = "{}", _0)]
+    Diagnostic(Diagnostic),
+
+    #[fail(display = "invalid token")]
+    InvalidToken { span: ByteSpan },
+
+    #[fail(display = "unrecognized token")]
+    UnrecognizedToken {
+        span: ByteSpan,
+        expected: Vec<String>,
+    },
+
+    #[fail(display = "extra token")]
+    ExtraToken { span: ByteSpan },
+
+    #[fail(display = "unexpected eof")]
+    UnexpectedEOF { expected: Vec<String> },
+}
+impl From<ParseError> for ParserError {
+    fn from(err: ParseError) -> ParserError {
+        match err {
+            lalrpop_util::ParseError::InvalidToken { location } => ParserError::InvalidToken {
+                span: ByteSpan::new(location, location),
+            },
+            lalrpop_util::ParseError::UnrecognizedToken {
+                token: None,
+                expected,
+            } => ParserError::UnexpectedEOF { expected },
+            lalrpop_util::ParseError::UnrecognizedToken {
+                token: Some((start, _, end)),
+                expected,
+            } => ParserError::UnrecognizedToken {
+                span: ByteSpan::new(start, end),
+                expected,
+            },
+            lalrpop_util::ParseError::ExtraToken {
+                token: (start, _, end),
+            } => ParserError::ExtraToken {
+                span: ByteSpan::new(start, end),
+            },
+            lalrpop_util::ParseError::User { error: err } => err.into(),
+        }
+    }
+}
+impl From<std::io::Error> for ParserError {
+    fn from(err: std::io::Error) -> ParserError {
+        ParserError::IO(err)
+    }
+}
+impl From<PreprocessorError> for ParserError {
+    fn from(err: PreprocessorError) -> ParserError {
+        ParserError::Preprocessor(err)
+    }
+}
+impl From<SourceError> for ParserError {
+    fn from(err: SourceError) -> ParserError {
+        ParserError::Source(err)
+    }
+}
+impl ParserError {
+    pub fn span(&self) -> Option<ByteSpan> {
+        match self {
+            ParserError::Preprocessor(ref err) => err.span(),
+            ParserError::InvalidToken { ref span, .. } => Some(span.clone()),
+            ParserError::UnrecognizedToken { ref span, .. } => Some(span.clone()),
+            ParserError::ExtraToken { ref span, .. } => Some(span.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn to_diagnostic(&self) -> Diagnostic {
+        let span = self.span();
+        let msg = self.to_string();
+        match *self {
+            ParserError::Diagnostic(ref d) => d.clone(),
+            ParserError::Preprocessor(ref err) => err.to_diagnostic(),
+            ParserError::Source(ref err) => err.to_diagnostic(),
+            ParserError::IO(_) => Diagnostic::new_error("i/o failed")
+                .with_label(Label::new_primary(span.unwrap()).with_message(msg)),
+            ParserError::UnrecognizedToken { ref expected, .. } => {
+                Diagnostic::new_error(format!("expected: {}", expected.join(", ")))
+                    .with_label(Label::new_primary(span.unwrap()).with_message(msg))
+            }
+            _ if span.is_some() => {
+                Diagnostic::new_error(msg).with_label(Label::new_primary(span.unwrap()))
+            }
+            _ => Diagnostic::new_error(msg),
+        }
+    }
+}

--- a/frontend/src/parser/grammar.lalrpop
+++ b/frontend/src/parser/grammar.lalrpop
@@ -1,0 +1,1077 @@
+//-*- mode: rust -*-
+use rug::Integer;
+use diagnostics::{ByteSpan, ByteIndex, Diagnostic, Label};
+
+use crate::lexer::{Token, Symbol, Ident};
+use crate::preprocessor::PreprocessorError;
+
+use super::ParseError;
+use super::ast::*;
+
+grammar(errs: &mut Vec<ParseError>);
+
+// The following are _not_ non-terminals, but macros
+// which can be identified by the generic type parameter,
+//
+// Currently all of the macros expect the name of the corresponding
+// non-terminal to have a type of the same name, a macro can
+// be written to handle differing non-terminal/type combinations by
+// adding a second type parameter used only in the type signature
+
+// Semicolon-delimited with at least one element
+Semi<T>: Vec<T> = {
+    <v:(<T> ";")*> <e:T> => {
+        let mut v = v;
+        v.push(e);
+        v
+    }
+};
+
+// Comma-delimited with at least one element
+Comma<T>: Vec<T> = {
+    <v:(<T> ",")*> <e:T> => {
+        let mut v = v;
+        v.push(e);
+        v
+    }
+};
+
+// Comma-delimited with zero or more elements
+CommaOpt<T>: Vec<T> = {
+    <v:(<T> ",")*> => v,
+};
+
+// Dash-delimited with at least one element
+Dash<T>: Vec<T> = {
+    <v:(<T> "-")*> <e:T> => {
+        let mut v = v;
+        v.push(e);
+        v
+    }
+};
+
+pub Module: Module = {
+    <l:@L> "COMMENT"* "-" "module" "(" <name:atom>  ")" "." "COMMENT"* <body:ModuleBody?> <r:@R> => {
+        let body = match body {
+            None => Vec::new(),
+            Some(body) => body,
+        };
+        Module::new(errs, ByteSpan::new(l, r), name, body)
+    }
+};
+
+ModuleBody: Vec<TopLevel> = TopLevel+;
+
+TopLevel: TopLevel = {
+    <FunctionDefinition>
+        => TopLevel::Function(<>),
+    <RecordDeclaration>
+        => TopLevel::Record(<>),
+    <AttributeDefinition>
+        => TopLevel::Attribute(<>),
+};
+
+// Top-level Functions
+
+FunctionDefinition: NamedFunction = {
+    <l:@L> <clauses:Semi<FunctionHead>> "." <r:@R>
+        =>? NamedFunction::new(errs, span!(l, r), clauses),
+};
+
+FunctionHead: FunctionClause = {
+    <l:@L> <a:atom> "(" ")" <g:Guards?> "->" <body:Comma<Expr>> <r:@R> => {
+        FunctionClause::new(span!(l, r), Some(a), Vec::new(), g, body)
+    },
+    <l:@L> <a:atom> "(" <params:Comma<Pattern>> ")" <g:Guards?> "->" <body:Comma<Expr>> <r:@R> => {
+        FunctionClause::new(span!(l, r), Some(a), params, g, body)
+    }
+};
+
+FunctionClause: FunctionClause = {
+    <l:@L> <a:atom?> "(" ")" <g:Guards?> "->" <body:Comma<Expr>> <r:@R> => {
+        FunctionClause::new(span!(l, r), a, Vec::new(), g, body)
+    },
+    <l:@L> <a:atom?> "(" <params:Comma<Pattern>> ")" <g:Guards?> "->" <body:Comma<Expr>> <r:@R> => {
+        FunctionClause::new(span!(l, r), a, params, g, body)
+    }
+};
+
+Guards: Vec<Guard> = "when" <Semi<Guard>>;
+
+Guard: Guard = <l:@L> <conditions:Comma<Expr>> <r:@R>
+    => Guard { span: span!(l, r), conditions };
+
+
+FunctionName: PartiallyResolvedFunctionName = {
+    <l:@L> <function:atom> "/" <arity:arity> <r:@R> => {
+        PartiallyResolvedFunctionName {
+            span: span!(l, r),
+            function,
+            arity,
+        }
+    }
+};
+
+// Attributes
+
+AttributeDefinition: Attribute = {
+    <l:@L> "-" "vsn" "(" <vsn:Atomic> ")" "." <r:@R>
+        => Attribute::Vsn(span!(l, r), vsn),
+    <l:@L> "-" "compile" "(" <opts:Constant> ")" "." <r:@R>
+        => Attribute::Compile(span!(l, r), opts),
+    <l:@L> "-" "import" "(" <module:atom> "," "[" <imports:Comma<FunctionName>> "]" ")" "." <r:@R>
+        => Attribute::Import(span!(l, r), module, imports),
+    <l:@L> "-" "export" "(" "[" <exports:Comma<FunctionName>> "]" ")" "." <r:@R>
+        => Attribute::Export(span!(l, r), exports),
+    <l:@L> "-" "export_type" "(" "[" <exports:Comma<FunctionName>> "]" ")" "." <r:@R>
+        => Attribute::ExportType(span!(l, r), exports),
+    <l:@L> "-" "behaviour" "(" <module:atom> ")" "." <r:@R>
+        => Attribute::Behaviour(span!(l, r), module),
+    TypeAttribute,
+    TypeSpecAttribute,
+    CallbackAttribute,
+    DeprecatedAttribute,
+};
+
+RecordDeclaration: Record = {
+    <l:@L> "-" "record" "(" <name:atom> "," <fields:TypedRecordFields> ")" "." <r:@R>
+        => Record { span: span!(l, r), name, fields },
+};
+
+TypeAttribute: Attribute = {
+    <l:@L> "-" "type" <def:TypeDef> <r:@R> => {
+        let mut def = def;
+        def.span = span!(l, r);
+        Attribute::Type(def)
+    },
+    <l:@L> "-" "opaque" <def:TypeDef> <r:@R> => {
+        let mut def = def;
+        def.span = span!(l, r);
+        def.opaque = true;
+        Attribute::Type(def)
+    },
+};
+
+TypeSpecAttribute: Attribute = {
+    <l:@L> "-" "spec" <spec:TypeSpec> <r:@R> => {
+        let mut spec = spec;
+        spec.span = span!(l, r);
+        Attribute::Spec(spec)
+    }
+};
+
+CallbackAttribute: Attribute = {
+    <l:@L> "-" "callback" <spec:TypeSpec> <r:@R> => {
+        let callback = Callback {
+            span: span!(l, r),
+            optional: false,
+            module: spec.module,
+            function: spec.function,
+            sigs: spec.sigs,
+        };
+        Attribute::Callback(callback)
+    },
+    <l:@L> "-" "optional_callback" <spec:TypeSpec> <r:@R> => {
+        let callback = Callback {
+            span: span!(l, r),
+            optional: true,
+            module: spec.module,
+            function: spec.function,
+            sigs: spec.sigs,
+        };
+        Attribute::Callback(callback)
+    }
+};
+
+DeprecatedAttribute: Attribute = {
+    <l:@L> "-" "deprecated" "(" <a:atom> <flag:("," <DeprecatedFlag>)?>  ")" "." <r:@R> =>? {
+        match a.as_str().get() {
+            "module" => {
+                Ok(Attribute::Deprecation(vec![
+                    Deprecation::Module {
+                        span: span!(l, r),
+                        flag: flag.unwrap_or(DeprecatedFlag::Eventually),
+                    }
+                ]))
+            }
+            other => {
+                Err(to_lalrpop_err!(PreprocessorError::Diagnostic(
+                    Diagnostic::new_warning("invalid deprecated attribute")
+                        .with_label(Label::new_primary(span!(l, r))
+                            .with_message("expected 'module', '{module, Flag}', 'Function/Arity', or '{Function/Arity, Flag}'"))
+                )))
+            }
+        }
+    },
+    "-" "deprecated" "(" <d:Deprecation> ")" "."
+        => Attribute::Deprecation(vec![d]),
+    "-" "deprecated" "(" "[" <ds:Comma<Deprecation>> "]"  ")" "."
+        => Attribute::Deprecation(ds),
+};
+
+Deprecation: Deprecation = {
+    <l:@L> <function:FunctionName> <r:@R>
+        => Deprecation::Function { span: span!(l, r), function, flag: DeprecatedFlag::Eventually },
+    <l:@L> "{" <function:FunctionName> "," <flag:DeprecatedFlag> "}" <r:@R>
+        => Deprecation::Function { span: span!(l, r), function, flag },
+    <l:@L> "{" <function:atom> "," <arity:arity> "," <flag:DeprecatedFlag> "}" <r:@R> => {
+        let span = span!(l, r);
+        let f = PartiallyResolvedFunctionName {
+            span: span.clone(),
+            function,
+            arity,
+        };
+        Deprecation::Function { span, function: f, flag }
+    }
+};
+
+DeprecatedFlag: DeprecatedFlag = {
+    <l:@L> <flag:atom> <r:@R> => {
+        match flag.as_str().get() {
+            "eventually" => DeprecatedFlag::Eventually,
+            "next_version" => DeprecatedFlag::NextVersion,
+            "next_major_release" => DeprecatedFlag::NextMajorRelease,
+            other => {
+                errs.push(to_lalrpop_err!(ParserError::Diagnostic(
+                    Diagnostic::new_warning("invalid deprecation flag")
+                        .with_label(Label::new_primary(span!(l, r))
+                            .with_message(format!("expected one of 'eventually', 'next_version', or 'next_major_release', got '{}'", other)))
+                )));
+                DeprecatedFlag::Eventually
+            }
+        }
+    }
+};
+
+UserAttribute: Attribute = {
+    <l:@L> "-" <name:atom> "(" <value:Constant> ")" "." <r:@R>
+        => Attribute::Custom(UserAttribute { span: span!(l, r), name, value }),
+};
+
+TypedRecordFields: Vec<RecordField> = {
+    "{" "}" => Vec::new(),
+    "{" <Comma<TypedRecordField>> "}"
+};
+
+TypedRecordField: RecordField = {
+    <l:@L> <name:atom> <value:("=" <Expr>)?> <ty:("::" <TopType100>)?> <r:@R>
+        => RecordField { span: span!(l, r), name: Name::Atom(name), value, ty },
+};
+
+// Type Specifications
+
+TypeDef: TypeDef = {
+    "(" <TypeDef100> ")" => (<>),
+    TypeDef100,
+};
+
+TypeDef100: TypeDef = {
+    <name:atom> "(" <params:CommaOpt<Ident>> ")" "::" <ty:TopType100> "." <r:@R>
+        => TypeDef { span: ByteSpan::default(), name, params, ty, opaque: false },
+};
+
+TypeSpec: TypeSpec = {
+    "(" <module:(<Ident> ":")?> <function:Ident> <sigs:Semi<TypeSig>> ")" "."
+        => TypeSpec { span: ByteSpan::default(), module, function, sigs },
+    <module:(<Ident> ":")?> <function:Ident> <sigs:Semi<TypeSig>> "."
+        => TypeSpec { span: ByteSpan::default(), module, function, sigs },
+};
+
+TypeSig: TypeSig = {
+    <l:@L> "(" ")" "->" <ret:TopType100> <guards:("when" <Comma<TypeGuard>>)?> <r:@R>
+        => TypeSig { span: span!(l, r), params: Vec::new(), ret: Box::new(ret), guards },
+    <l:@L> "(" <params:Comma<TopType>> ")" "->" <ret:TopType100> <guards:("when" <Comma<TypeGuard>>)?> <r:@R>
+        => TypeSig { span: span!(l, r), params, ret: Box::new(ret), guards },
+};
+
+TypeGuard: TypeGuard = {
+    // is_subtype is not supported >OTP 19, but is allowed for backwards compatibility
+    <l:@L> <name:atom> "(" <var:Ident> "," <ty:TopType> ")" <r:@R> =>? {
+        match name.name.as_str().get() {
+            "is_subtype" =>
+                Ok(TypeGuard { span: span!(l, r), var, ty }),
+            name => {
+                Err(lalrpop_util::ParseError::User {
+                    error: PreprocessorError::Diagnostic(
+                        Diagnostic::new_error("invalid type constraint")
+                            .with_label(Label::new_primary(span!(l, r))
+                                .with_message(format!("expected constraint in the form `Name :: Type`")))
+                    )
+                })
+            }
+        }
+    },
+    <l:@L> <var:Ident> "::" <ty:TopType100> <r:@R>
+        => TypeGuard { span: span!(l, r), var, ty },
+};
+
+TopType: Type = {
+    <l:@L> <name:Ident> "::" <ty:TopType100> <r:@R>
+        => Type::Annotated { span: span!(l, r), name, ty: Box::new(ty)  },
+    TopType100,
+};
+
+TopType100: Type = {
+    <l:@L> <lhs:Type200> "|" <rhs:TopType100> <r:@R>
+        => Type::union(span!(l, r), lhs, rhs),
+    Type200,
+};
+
+Type200: Type = {
+    <l:@L> <lhs:Type300> ".." <rhs:Type300> <r:@R>
+        => Type::Range { span: span!(l, r), start: Box::new(lhs), end: Box::new(rhs) },
+    Type300,
+};
+
+Type300: Type = {
+    <l:@L> <lhs:Type300> <op:TypeAddOp> <rhs:Type400> <r:@R>
+        => Type::BinaryOp { span: span!(l, r), lhs: Box::new(lhs), op, rhs: Box::new(rhs) },
+    Type400,
+};
+
+Type400: Type = {
+    <l:@L> <lhs:Type400> <op:TypeMultOp> <rhs:Type500> <r:@R>
+        => Type::BinaryOp { span: span!(l, r), lhs: Box::new(lhs), op, rhs: Box::new(rhs) },
+    Type500,
+};
+
+Type500: Type = {
+    <l:@L> <op:TypeUnaryOp> <rhs:Type600> <r:@R>
+        => Type::UnaryOp { span: span!(l, r), op, rhs: Box::new(rhs) },
+    Type600,
+};
+
+Type600: Type = {
+    <l:@L> <fun:atom> "(" ")" <r:@R>
+        => Type::Generic { span: span!(l, r), fun, params: Vec::new() },
+    <l:@L> <fun:atom> "(" <params:Comma<TopType>> ")" <r:@R>
+        => Type::Generic { span: span!(l, r), fun, params },
+    Type700,
+};
+
+Type700: Type = {
+    <l:@L> <module:atom> ":" <fun:atom> "(" ")" <r:@R>
+        => Type::Remote { span: span!(l, r), module, fun, args: Vec::new() },
+    <l:@L> <module:atom> ":" <fun:atom> "(" <args:Comma<TopType>> ")" <r:@R>
+        => Type::Remote { span: span!(l, r), module, fun, args },
+    TypeMax,
+};
+
+TypeMax: Type = {
+    "(" <ty:TopType> ")"
+        => ty,
+    <l:@L> "[" "]" <r:@R>
+        => Type::Nil(span!(l, r)),
+    <l:@L> "[" <lt:TopType> "]" <r:@R>
+        => Type::List(span!(l, r), Box::new(lt)),
+    <l:@L> "[" <lt:TopType> "," "..." "]" <r:@R>
+        => Type::NonEmptyList(span!(l, r), Box::new(lt)),
+    <l:@L> "{" "}" <r:@R>
+        => Type::Tuple(span!(l, r), Vec::new()),
+    <l:@L> "{" <et:Comma<TopType>> "}" <r:@R>
+        => Type::Tuple(span!(l, r), et),
+    <l:@L> "#" "{"  "}" <r:@R>
+        => Type::Map(span!(l, r), Vec::new()),
+    <l:@L> "#" "{" <ft:Comma<MapFieldType>> "}" <r:@R>
+        => Type::Map(span!(l, r), ft),
+    <l:@L> "#" <record:atom> "{" "}" <r:@R>
+        => Type::Record(span!(l, r), record, Vec::new()),
+    <l:@L> "#" <record:atom> "{" <ft:Comma<RecordFieldType>> "}" <r:@R>
+        => Type::Record(span!(l, r), record, ft),
+    BinaryType,
+    <name:atom_or_var>
+        => Type::Name(name),
+    <l:@L> <i:int> <r:@R>
+        => Type::Integer(span!(l, r), i),
+    <l:@L> <c:char> <r:@R>
+        => Type::Char(span!(l, r), c),
+    FunType,
+};
+
+BinaryType: Type = {
+    <l:@L> "<<" ">>" <r:@R>
+        => Type::Binary(span!(l, r), 0, 0),
+    <l:@L> "<<" ident ":" <m:int> ">>" <r:@R>
+        => Type::Binary(span!(l, r), m, 0),
+    <l:@L> "<<" ident ":" ident "*" <n:int> ">>" <r:@R>
+        => Type::Binary(span!(l, r), 0, n),
+    <l:@L> "<<" ident ":" <m:int> "," ident ":" ident "*" <n:int> ">>" <r:@R>
+        => Type::Binary(span!(l, r), m, n),
+};
+
+FunType: Type = {
+    <l:@L> "fun" "(" "..." ")" <r:@R>
+        => Type::AnyFun(span!(l, r)),
+    <l:@L> "fun" "(" "(" ")" "->" <ret:TopType> ")" <r:@R>
+        => Type::Fun { span: span!(l, r), params: Vec::new(), ret: Box::new(ret) },
+    <l:@L> "fun" "(" "(" <params:Comma<TopType>> ")" "->" <ret:TopType> ")" <r:@R>
+        => Type::Fun { span: span!(l, r), params, ret: Box::new(ret) },
+};
+
+MapFieldType: Type = {
+    <l:@L> <key:TopType100> "=>" <val:TopType100> <r:@R>
+        => Type::KeyValuePair(span!(l, r), Box::new(key), Box::new(val)),
+    <l:@L> <key:TopType100> ":=" <val:TopType100> <r:@R>
+        => Type::KeyValuePair(span!(l, r), Box::new(key), Box::new(val)),
+};
+
+RecordFieldType: Type = {
+    <l:@L> <key:atom> "::" <val:TopType100> <r:@R>
+        => Type::Field(span!(l, r), key, Box::new(val)),
+};
+
+// Pattern Matching
+
+Pattern: Expr = {
+    <l:@L> <lhs:Pattern200> "=" <rhs:Pattern> <r:@R>
+        => Expr::Match(Match { span: span!(l, r), pattern: Box::new(lhs), expr: Box::new(rhs) }),
+    Pattern200
+};
+
+Pattern200: Expr = {
+    <l:@L> <lhs:Pattern300> <op:CompOp> <rhs:Pattern300> <r:@R>
+        => Expr::BinaryExpr(BinaryExpr { span: span!(l, r), lhs: Box::new(lhs), op, rhs: Box::new(rhs) }),
+    Pattern300
+};
+
+Pattern300: Expr = {
+    <l:@L> <lhs:Pattern400> <op:ListOp> <rhs:Pattern300> <r:@R>
+        => Expr::BinaryExpr(BinaryExpr { span: span!(l, r), lhs: Box::new(lhs), op, rhs: Box::new(rhs) }),
+    Pattern400
+};
+
+Pattern400: Expr = {
+    <l:@L> <lhs:Pattern400> <op:AddOp> <rhs:Pattern500> <r:@R>
+        => Expr::BinaryExpr(BinaryExpr { span: span!(l, r), lhs: Box::new(lhs), op, rhs: Box::new(rhs) }),
+    Pattern500
+};
+
+Pattern500: Expr = {
+    <l:@L> <lhs:Pattern500> <op:MultOp> <rhs:Pattern600> <r:@R>
+        => Expr::BinaryExpr(BinaryExpr { span: span!(l, r), lhs: Box::new(lhs), op, rhs: Box::new(rhs) }),
+    Pattern600
+};
+
+Pattern600: Expr = {
+    <l:@L> <op:PrefixOp> <rhs:Pattern700> <r:@R>
+        => Expr::UnaryExpr(UnaryExpr { span: span!(l, r), op, operand: Box::new(rhs) }),
+    MapPattern,
+    Pattern700
+};
+
+Pattern700: Expr = {
+    RecordPattern,
+    PatternMax
+};
+
+PatternMax: Expr = {
+    <i:Ident> => Expr::Var(i),
+    Atomic,
+    ListPattern,
+    Binary,
+    Tuple,
+    "(" <Pattern> ")"
+};
+
+ListPattern: Expr = {
+    <l:@L> "[" "]" <r:@R>
+        => Expr::Nil(Nil(span!(l, r))),
+    <l:@L> "[" <head:Pattern> <tail:TailPattern> <r:@R>
+        => Expr::Cons(Cons { span: span!(l, r), head: Box::new(head), tail: Box::new(tail) })
+};
+
+TailPattern: Expr = {
+    <l:@L> "]" <r:@R>
+        => Expr::Nil(Nil(span!(l, r))),
+    "|" <Pattern> "]",
+    <l:@L> "," <head:Pattern> <tail:TailPattern> <r:@R>
+        => Expr::Cons(Cons { span: span!(l, r), head: Box::new(head), tail: Box::new(tail) })
+};
+
+MapPattern: Expr = {
+    <l:@L> "#" <fields:MapTuplePattern> <r:@R>
+        => Expr::Map(Map { span: span!(l, r), fields }),
+    <l:@L> <lhs:PatternMax> "#" <fields:MapTuplePattern> <r:@R>
+        => Expr::MapProjection(MapProjection { span: span!(l, r), map: Box::new(lhs), fields }),
+    <l:@L> <lhs:MapPattern> "#" <fields:MapTuplePattern> <r:@R>
+        => Expr::MapProjection(MapProjection { span: span!(l, r), map: Box::new(lhs), fields }),
+};
+
+MapTuplePattern: Vec<MapField> = {
+    "{" "}" => Vec::new(),
+    "{" <Comma<MapFieldPattern>> "}"
+};
+
+MapFieldPattern: MapField = {
+    <l:@L> <key:Pattern> ":=" <value:Pattern> <r:@R>
+        => MapField::Exact { span: span!(l, r), key, value }
+};
+
+RecordPattern: Expr = {
+    <l:@L> "#" <name:atom> "." <field:atom> <r:@R>
+        => Expr::RecordIndex(RecordIndex { span: span!(l, r), name, field }),
+    <l:@L> "#" <name:atom> <fields:RecordTuplePattern> <r:@R>
+        => Expr::Record(Record { span: span!(l, r), name, fields }),
+};
+
+RecordTuplePattern: Vec<RecordField> = {
+    "{" "}" => Vec::new(),
+    "{" <Comma<RecordFieldPattern>> "}"
+};
+
+RecordFieldPattern: RecordField = {
+    <l:@L> <name:atom_or_var> "=" <value:Pattern> <r:@R>
+        => RecordField { span: span!(l, r), name, value: Some(value), ty: None },
+};
+
+// Expressions
+
+pub Expr: Expr = {
+    <l:@L> "catch" <e:Expr> <r:@R>
+        => Expr::Catch(Catch { span: span!(l, r), expr: Box::new(e) }),
+    Expr100,
+}
+
+Expr100: Expr = {
+    // We would like to use Pattern200 here, but this leads to an ambiguity conflict
+    // between non-terminals which are same in structure but different type, e.g. Tuple/TuplePattern,
+    // so we just need to be aware that Expr::Match is really a pattern expression
+    <l:@L> <lhs:Expr150> "=" <rhs:Expr100> <r:@R>
+        => Expr::Match(Match { span: span!(l, r), pattern: Box::new(lhs), expr: Box::new(rhs) }),
+    <l:@L> <lhs:Expr150> "!" <rhs:Expr100> <r:@R>
+        => Expr::BinaryExpr(BinaryExpr { span: span!(l, r), lhs: Box::new(lhs), op: BinaryOp::Send, rhs: Box::new(rhs) }),
+    Expr150
+};
+
+Expr150: Expr = {
+    <l:@L> <lhs:Expr160> "orelse" <rhs:Expr150> <r:@R>
+        => Expr::BinaryExpr(BinaryExpr { span: span!(l, r), lhs: Box::new(lhs), op: BinaryOp::OrElse, rhs: Box::new(rhs) }),
+    Expr160
+};
+
+Expr160: Expr = {
+    <l:@L> <lhs:Expr200> "andalso" <rhs:Expr160> <r:@R>
+        => Expr::BinaryExpr(BinaryExpr { span: span!(l, r), lhs: Box::new(lhs), op: BinaryOp::AndAlso, rhs: Box::new(rhs) }),
+    Expr200
+};
+
+Expr200: Expr = {
+    <l:@L> <lhs:Expr300> <op:CompOp> <rhs:Expr300> <r:@R>
+        => Expr::BinaryExpr(BinaryExpr { span: span!(l, r), lhs: Box::new(lhs), op, rhs: Box::new(rhs) }),
+    Expr300
+};
+
+Expr300: Expr = {
+    <l:@L> <lhs:Expr400> <op:ListOp> <rhs:Expr300> <r:@R>
+        => Expr::BinaryExpr(BinaryExpr { span: span!(l, r), lhs: Box::new(lhs), op, rhs: Box::new(rhs) }),
+    Expr400
+};
+
+Expr400: Expr = {
+    <l:@L> <lhs:Expr400> <op:AddOp> <rhs:Expr500> <r:@R>
+        => Expr::BinaryExpr(BinaryExpr { span: span!(l, r), lhs: Box::new(lhs), op, rhs: Box::new(rhs) }),
+    Expr500
+};
+
+Expr500: Expr = {
+    <l:@L> <lhs:Expr500> <op:MultOp> <rhs:Expr600> <r:@R>
+        => Expr::BinaryExpr(BinaryExpr { span: span!(l, r), lhs: Box::new(lhs), op, rhs: Box::new(rhs) }),
+    Expr600
+};
+
+Expr600: Expr = {
+    <l:@L> <op:PrefixOp> <rhs:Expr700> <r:@R>
+        => Expr::UnaryExpr(UnaryExpr { span: span!(l, r), op, operand: Box::new(rhs) }),
+    MapExpr,
+    Expr700
+};
+
+Expr700: Expr = {
+    Apply,
+    RecordExpr,
+    Expr800
+};
+
+Expr800: Expr = {
+    <l:@L> <lhs:ExprMax> ":" <rhs:ExprMax> <r:@R>
+        => Expr::Remote(Remote { span: span!(l, r), module: Box::new(lhs), function: Box::new(rhs) }),
+    ExprMax
+};
+
+ExprMax: Expr = {
+    <i:Ident> => Expr::Var(i),
+    Atomic,
+    Tuple,
+    List,
+    Binary,
+    ListComprehension,
+    BinaryComprehension,
+    "(" <Expr> ")",
+    <l:@L> "begin" <body:Comma<Expr>> "end" <r:@R>
+        => Expr::Begin(Begin { span: span!(l, r), body }),
+    If,
+    Case,
+    Receive,
+    Try,
+    Fun,
+};
+
+Fun: Expr = {
+    "fun" <fun:FunctionName>
+        => Expr::FunctionName(FunctionName::PartiallyResolved(fun)),
+    <l:@L> "fun" <module:atom_or_var> ":" <function:atom_or_var> "/" <arity:arity> <r:@R> =>
+        Expr::FunctionName(FunctionName::detect(span!(l, r), Some(module), function, arity)),
+    <l:@L> "fun" <clauses:Semi<FunctionHead>> "end" <r:@R> =>? {
+        match Function::new(errs, span!(l, r), clauses) {
+            Ok(fun) => Ok(Expr::Fun(fun)),
+            Err(err) => Err(err)
+        }
+    },
+};
+
+If: Expr = {
+    <l:@L> "if" <clauses:Semi<IfClause>> "end" <r:@R>
+        => Expr::If(If { span: span!(l, r), clauses })
+};
+IfClause: IfClause = {
+    <l:@L> <conditions:Comma<Expr>> "->" <body:Comma<Expr>> <r:@R>
+        => IfClause { span: span!(l, r), conditions, body }
+};
+
+Case: Expr = {
+    <l:@L> "case" <input:Expr> "of" <clauses:Semi<Clause>> "end" <r:@R>
+        => Expr::Case(Case { span: span!(l, r), expr: Box::new(input), clauses })
+};
+
+Receive: Expr = {
+    <l:@L> "receive" <after:After> "end" <r:@R>
+        => Expr::Receive(Receive { span: span!(l, r), clauses: None, after: Some(after) }),
+    <l:@L> "receive" <clauses:Semi<Clause>> <after:After?> "end" <r:@R>
+        => Expr::Receive(Receive { span: span!(l, r), clauses: Some(clauses), after })
+};
+
+After: After = {
+    <l:@L> "after" <timeout:Expr> "->" <body:Comma<Expr>> <r:@R>
+        => After { span: span!(l, r), timeout: Box::new(timeout), body }
+};
+
+Try: Expr = {
+    <l:@L> "try" <exprs:Comma<Expr>> "of" <clauses:Semi<Clause>> <catch:TryCatch>
+        => Expr::Try(Try { span: span!(l, catch.2), exprs: Some(exprs), clauses: Some(clauses), catch_clauses: catch.0, after: catch.1 }),
+    <l:@L> "try" <exprs:Comma<Expr>> <catch:TryCatch>
+        => Expr::Try(Try { span: span!(l, catch.2), exprs: None, clauses: None, catch_clauses: catch.0, after: catch.1 })
+};
+
+TryCatch: (Option<Vec<TryClause>>, Option<Vec<Expr>>, ByteIndex) = {
+    "catch" <clauses:Semi<TryClause>> "end" <r:@R>
+        => (Some(clauses), None, r),
+    "catch" <clauses:Semi<TryClause>> "after" <body:Comma<Expr>> "end" <r:@R>
+        => (Some(clauses), Some(body), r),
+    "after" <body:Comma<Expr>> "end" <r:@R>
+        => (None, Some(body), r)
+};
+
+TryClause: TryClause = {
+    <l:@L> <error:Pattern> <guard:Guards?> "->" <body:Comma<Expr>> <r:@R>
+        => TryClause { span: span!(l, r), kind: Name::Atom(Ident::from_str("throw")), error, guard, trace: Ident::from_str("_"), body },
+    <l:@L> <kind:atom_or_var> ":" <error:Pattern> <guard:Guards?> "->" <body:Comma<Expr>> <r:@R>
+        => TryClause { span: span!(l, r), kind, error, guard, trace: Ident::from_str("_"), body },
+    <l:@L> <kind:atom_or_var> ":" <error:Pattern> ":" <trace:Ident> <guard:Guards?> "->" <body:Comma<Expr>> <r:@R>
+        => TryClause { span: span!(l, r), kind, error, guard, trace, body },
+};
+
+Clause: Clause = {
+    <l:@L> <pattern:Pattern> <guard:Guards?> "->" <body:Comma<Expr>> <r:@R>
+        => Clause { span: span!(l, r), pattern, guard, body }
+};
+
+Apply: Expr = {
+    <l:@L> <lhs:Expr800> "(" ")" <r:@R>
+        => Expr::Apply(Apply { span: span!(l, r), callee: Box::new(lhs), args: Vec::new()  }),
+    <l:@L> <lhs:Expr800> "(" <args:Comma<Expr>> ")" <r:@R>
+        => Expr::Apply(Apply { span: span!(l, r), callee: Box::new(lhs), args })
+};
+
+ListComprehension: Expr = {
+    <l:@L> "[" <body:Expr> "||" <qualifiers:Comma<ComprehensionExpr>> "]" <r:@R>
+        => Expr::ListComprehension(ListComprehension { span: span!(l, r), body: Box::new(body), qualifiers }),
+};
+
+BinaryComprehension: Expr = {
+    <l:@L> "<<" <body:ExprMax> "||" <qualifiers:Comma<ComprehensionExpr>> ">>" <r:@R>
+        => Expr::BinaryComprehension(BinaryComprehension { span: span!(l, r), body: Box::new(body), qualifiers }),
+};
+
+ComprehensionExpr: Expr = {
+    <l:@L> <lhs:Binary> "<=" <rhs:Expr> <r:@R>
+        => Expr::BinaryGenerator(BinaryGenerator { span: span!(l, r), pattern: Box::new(lhs), expr: Box::new(rhs) }),
+    <l:@L> <lhs:Expr> "<-" <rhs:Expr> <r:@R>
+        => Expr::Generator(Generator { span: span!(l, r), pattern: Box::new(lhs), expr: Box::new(rhs) }),
+    Expr,
+};
+
+Binary: Expr = {
+    <l:@L> "<<" ">>" <r:@R>
+        => Expr::Binary(Binary { span: span!(l, r), elements: Vec::new() }),
+    <l:@L> "<<" <elements:Comma<BinaryElement>> ">>" <r:@R>
+        => Expr::Binary(Binary { span: span!(l, r), elements }),
+};
+
+BinaryElement: BinaryElement = {
+    <l:@L> <be:BitExpr> <bs:BitSize?> <bt:BitTypeList?> <r:@R>
+        => BinaryElement { span: span!(l, r), bit_expr: be, bit_size: bs, bit_type: bt },
+};
+
+BitExpr: Expr = {
+    <l:@L> <op:PrefixOp> <rhs:ExprMax> <r:@R>
+        => Expr::UnaryExpr(UnaryExpr { span: span!(l, r), op, operand: Box::new(rhs) }),
+    ExprMax,
+};
+
+BitSize: Expr = {
+    ":" <ExprMax>,
+};
+
+BitTypeList: Vec<BitType> = {
+    "/" <bts:Dash<BitType>> => bts,
+};
+
+BitType: BitType = {
+    <l:@L> <ty:atom> ":" <i:int> <r:@R>
+        => BitType::Sized(span!(l, r), ty, i),
+    <l:@L> <ty:atom> <r:@R>
+        => BitType::Name(span!(l, r), ty)
+};
+
+Tuple: Expr = {
+    <l:@L> "{" "}" <r:@R>
+        => Expr::Tuple(Tuple { span: span!(l, r), elements: Vec::new() }),
+    <l:@L> "{" <elements:Comma<Expr>> "}" <r:@R>
+        => Expr::Tuple(Tuple { span: span!(l, r), elements })
+};
+
+List: Expr = {
+    <l:@L> "[" "]" <r:@R>
+        => Expr::Nil(Nil(span!(l, r))),
+    <l:@L> "[" <head:Expr> <tail:Tail> <r:@R>
+        => Expr::Cons(Cons { span: span!(l, r), head: Box::new(head), tail: Box::new(tail) })
+};
+
+Tail: Expr = {
+    <l:@L> "]" <r:@R>
+        => Expr::Nil(Nil(span!(l, r))),
+    "|" <Expr> "]",
+    <l:@L> "," <head:Expr> <tail:Tail> <r:@R>
+        => Expr::Cons(Cons { span: span!(l, r), head: Box::new(head), tail: Box::new(tail) })
+};
+
+MapExpr: Expr = {
+    <l:@L> "#" <fields:MapTuple> <r:@R>
+        => Expr::Map(Map { span: span!(l, r), fields }),
+    <l:@L> <map:ExprMax> "#" <updates:MapTuple> <r:@R>
+        => Expr::MapUpdate(MapUpdate { span: span!(l, r), map: Box::new(map), updates }),
+    <l:@L> <map:MapExpr> "#" <updates:MapTuple> <r:@R>
+        => Expr::MapUpdate(MapUpdate { span: span!(l, r), map: Box::new(map), updates }),
+};
+
+MapTuple: Vec<MapField> = {
+    "{" "}" => Vec::new(),
+    "{" <Comma<MapField>> "}"
+};
+
+MapField: MapField = {
+    MapFieldAssoc,
+    MapFieldExact
+};
+MapFieldAssoc: MapField = {
+    <l:@L> <key:MapKey> "=>" <value:Expr> <r:@R>
+        => MapField::Assoc { span: span!(l, r), key, value }
+};
+MapFieldExact: MapField = {
+    <l:@L> <key:MapKey> ":=" <value:Expr> <r:@R>
+        => MapField::Exact { span: span!(l, r), key, value }
+};
+
+MapKey: Expr = Expr;
+
+RecordExpr: Expr = {
+    <l:@L> "#" <name:atom> "." <field:atom> <r:@R>
+        => Expr::RecordIndex(RecordIndex { span: span!(l, r), name, field }),
+    <l:@L> "#" <name:atom> <fields:RecordTuple> <r:@R>
+        => Expr::Record(Record { span: span!(l, r), name, fields }),
+
+    <l:@L> <lhs:ExprMax> "#" <name:atom> "." <field:atom> <r:@R>
+        => Expr::RecordAccess(RecordAccess { span: span!(l, r), record: Box::new(lhs), name, field }),
+    <l:@L> <lhs:ExprMax> "#" <name:atom> <updates:RecordTuple> <r:@R>
+        => Expr::RecordUpdate(RecordUpdate { span: span!(l, r), record: Box::new(lhs), name, updates }),
+
+    <l:@L> <lhs:RecordExpr> "#" <name:atom> "." <field:atom> <r:@R>
+        => Expr::RecordAccess(RecordAccess { span: span!(l, r), record: Box::new(lhs), name, field }),
+    <l:@L> <lhs:RecordExpr> "#" <name:atom> <updates:RecordTuple> <r:@R>
+        => Expr::RecordUpdate(RecordUpdate { span: span!(l, r), record: Box::new(lhs), name, updates }),
+};
+
+RecordTuple: Vec<RecordField> = {
+    "{" "}" => Vec::new(),
+    "{" <Comma<RecordField>> "}"
+};
+
+RecordField: RecordField = {
+    <l:@L> <name:atom_or_var> "=" <value:Expr> <r:@R>
+        => RecordField { span: span!(l, r), name, value: Some(value), ty: None },
+};
+
+Constant: Expr = {
+    ConstantTuple,
+    ConstantList,
+    ConstantMapExpr,
+    Atomic,
+};
+
+
+ConstantTuple: Expr = {
+    <l:@L> "{" "}" <r:@R>
+        => Expr::Tuple(Tuple { span: span!(l, r), elements: Vec::new() }),
+    <l:@L> "{" <elements:Comma<Constant>> "}" <r:@R>
+        => Expr::Tuple(Tuple { span: span!(l, r), elements })
+};
+
+ConstantList: Expr = {
+    <l:@L> "[" "]" <r:@R>
+        => Expr::Nil(Nil(span!(l, r))),
+    <l:@L> "[" <head:Constant> <tail:ConstantTail> <r:@R>
+        => Expr::Cons(Cons { span: span!(l, r), head: Box::new(head), tail: Box::new(tail) })
+};
+
+ConstantTail: Expr = {
+    <l:@L> "]" <r:@R>
+        => Expr::Nil(Nil(span!(l, r))),
+    "|" <Constant> "]",
+    <l:@L> "," <head:Constant> <tail:ConstantTail> <r:@R>
+        => Expr::Cons(Cons { span: span!(l, r), head: Box::new(head), tail: Box::new(tail) })
+};
+
+ConstantMapExpr: Expr = {
+    <l:@L> "#" <fields:ConstantMapTuple> <r:@R>
+        => Expr::Map(Map { span: span!(l, r), fields }),
+};
+
+ConstantMapTuple: Vec<MapField> = {
+    "{" "}" => Vec::new(),
+    "{" <Comma<ConstantMapField>> "}"
+};
+
+ConstantMapField: MapField = {
+    <l:@L> <key:MapKey> "=>" <value:Constant> <r:@R>
+        => MapField::Assoc { span: span!(l, r), key, value }
+};
+
+ConstantMapKey: Expr = Constant;
+
+Atomic: Expr = {
+    <l:@L> <c:char> <r:@R>
+        => Expr::Literal(Literal::Char(span!(l, r), c)),
+    <Integer>
+        => Expr::Literal(<>),
+    <l:@L> <f:float> <r:@R>
+        => Expr::Literal(Literal::Float(span!(l, r), f)),
+    <atom>
+        => Expr::Literal(Literal::Atom(<>)),
+    <l:@L> <s:string> <r:@R>
+        => Expr::Literal(Literal::String(Ident::new(s, span!(l, r)))),
+};
+
+#[inline]
+atom_or_var: Name = {
+    <a:atom> => Name::Atom(a),
+    <i:Ident> => Name::Var(i),
+};
+
+#[inline]
+atom: Ident = <l:@L> <a:"atom"> <r:@R>
+    => Ident::new(a, span!(l, r));
+
+#[inline]
+Ident: Ident = <l:@L> <i:ident> <r:@R>
+    => Ident::new(i, span!(l, r));
+
+#[inline]
+Integer: Literal = {
+    <l:@L> <i:int> <r:@R>
+        => Literal::Integer(span!(l, r), i),
+    <l:@L> <i:bigint> <r:@R>
+        => Literal::BigInteger(span!(l, r), i)
+};
+
+#[inline]
+arity: usize = <i:int> => i as usize;
+
+#[inline]
+ident_or_integer: Expr = {
+    <i:Ident> => Expr::Var(i),
+    <i:Integer> => Expr::Literal(i)
+}
+
+PrefixOp: UnaryOp = {
+    "+" => UnaryOp::Plus,
+    "-" => UnaryOp::Minus,
+    "bnot" => UnaryOp::Bnot,
+    "not" => UnaryOp::Not,
+};
+
+MultOp: BinaryOp = {
+    "/" => BinaryOp::Divide,
+    "*" => BinaryOp::Multiply,
+    "div" => BinaryOp::Div,
+    "rem" => BinaryOp::Rem,
+    "band" => BinaryOp::Band,
+    "and" => BinaryOp::And,
+};
+
+AddOp: BinaryOp = {
+    "+" => BinaryOp::Add,
+    "-" => BinaryOp::Sub,
+    "bor" => BinaryOp::Bor,
+    "bxor" => BinaryOp::Bxor,
+    "bsl" => BinaryOp::Bsl,
+    "bsr" => BinaryOp::Bsr,
+    "or" => BinaryOp::Or,
+    "xor" => BinaryOp::Xor,
+};
+
+TypeMultOp: BinaryOp = {
+    "*" => BinaryOp::Multiply,
+    "div" => BinaryOp::Div,
+    "rem" => BinaryOp::Rem,
+    "band" => BinaryOp::Band,
+};
+
+TypeAddOp: BinaryOp = {
+    "+" => BinaryOp::Add,
+    "-" => BinaryOp::Sub,
+    "bor" => BinaryOp::Bor,
+    "bxor" => BinaryOp::Bxor,
+    "bsl" => BinaryOp::Bsl,
+    "bsr" => BinaryOp::Bsr,
+};
+
+TypeUnaryOp: UnaryOp = {
+    "+" => UnaryOp::Plus,
+    "-" => UnaryOp::Minus,
+    "bnot" => UnaryOp::Bnot,
+};
+
+ListOp: BinaryOp = {
+    "++" => BinaryOp::Append,
+    "--" => BinaryOp::Remove,
+};
+
+CompOp: BinaryOp = {
+    "==" => BinaryOp::Equal,
+    "/=" => BinaryOp::NotEqual,
+    "=<" => BinaryOp::Lte,
+    "<" => BinaryOp::Lt,
+    ">=" => BinaryOp::Gte,
+    ">" => BinaryOp::Gt,
+    "=:=" => BinaryOp::StrictEqual,
+    "=/=" => BinaryOp::StrictNotEqual
+};
+
+extern {
+    type Location = ByteIndex;
+    type Error = PreprocessorError;
+
+    enum Token {
+        // Docs
+        "COMMENT" => Token::Comment,
+        // Literals
+        char => Token::Char(<char>),
+        int => Token::Integer(<i64>),
+        bigint => Token::BigInteger(<Integer>),
+        float => Token::Float(<f64>),
+        "atom" => Token::Atom(<Symbol>),
+        string => Token::String(<Symbol>),
+        ident => Token::Ident(<Symbol>),
+        // Keywords and Symbols
+        "(" => Token::LParen,
+        ")" => Token::RParen,
+        "," => Token::Comma,
+        "->" => Token::RightStab,
+        "{" => Token::LBrace,
+        "}" => Token::RBrace,
+        "[" => Token::LBracket,
+        "]" => Token::RBracket,
+        "|" => Token::Bar,
+        "||" => Token::BarBar,
+        "<-" => Token::LeftStab,
+        ";" => Token::Semicolon,
+        ":" => Token::Colon,
+        "#" => Token::Pound,
+        "." => Token::Dot,
+        "after" => Token::After,
+        "begin" => Token::Begin,
+        "case" => Token::Case,
+        "try" => Token::Try,
+        "catch" => Token::Catch,
+        "end" => Token::End,
+        "fun" => Token::Fun,
+        "if" => Token::If,
+        "of" => Token::Of,
+        "receive" => Token::Receive,
+        "when" => Token::When,
+        "record" => Token::Record,
+        "spec" => Token::Spec,
+        "callback" => Token::Callback,
+        "optional_callback" => Token::OptionalCallback,
+        "import" => Token::Import,
+        "export" => Token::Export,
+        "export_type" => Token::ExportType,
+        "module" => Token::Module,
+        "compile" => Token::Compile,
+        "vsn" => Token::Vsn,
+        "on_load" => Token::OnLoad,
+        "behaviour" => Token::Behaviour,
+        "deprecated" => Token::Deprecated,
+        "type" => Token::Type,
+        "opaque" => Token::Opaque,
+        "andalso" => Token::AndAlso,
+        "orelse" => Token::OrElse,
+        "bnot" => Token::Bnot,
+        "not" => Token::Not,
+        "*" => Token::Star,
+        "/" => Token::Slash,
+        "div" => Token::Div,
+        "rem" => Token::Rem,
+        "band" => Token::Band,
+        "and" => Token::And,
+        "+" => Token::Plus,
+        "-" => Token::Minus,
+        "bor" => Token::Bor,
+        "bxor" => Token::Bxor,
+        "bsl" => Token::Bsl,
+        "bsr" => Token::Bsr,
+        "or" => Token::Or,
+        "xor" => Token::Xor,
+        "++" => Token::PlusPlus,
+        "--" => Token::MinusMinus,
+        "==" => Token::IsEqual,
+        "/=" => Token::IsNotEqual,
+        "=<" => Token::IsLessThanOrEqual,
+        "<" => Token::IsLessThan,
+        ">=" => Token::IsGreaterThanOrEqual,
+        ">" => Token::IsGreaterThan,
+        "=:=" => Token::IsExactlyEqual,
+        "=/=" => Token::IsExactlyNotEqual,
+        "<=" => Token::LeftArrow,
+        "=>" => Token::RightArrow,
+        ":=" => Token::ColonEqual,
+        "<<" => Token::BinaryStart,
+        ">>" => Token::BinaryEnd,
+        "!" => Token::Bang,
+        "=" => Token::Equals,
+        "::" => Token::ColonColon,
+        ".." => Token::DotDot,
+        "..." => Token::DotDotDot,
+        "?" => Token::Question,
+    }
+}

--- a/frontend/src/parser/macros.rs
+++ b/frontend/src/parser/macros.rs
@@ -1,0 +1,211 @@
+/// Construct a keyword list AST from a list of expressions, e.g.:
+///
+///     kwlist!(tuple!(atom!(key), var!(Value)))
+///
+/// It is required that elements are two-tuples, but no checking is done
+/// to make sure that the first element in each tuple is an atom
+#[allow(unused_macros)]
+macro_rules! kwlist {
+    ($($element:expr),*) => {
+        let mut elements = vec![$($element),*];
+        elements.reverse();
+        elements.fold(nil!(), |acc, (key, val)| {
+            cons!(Expr::Tuple(Tuple { span: ByteSpan::default(), elements: vec![key, val] }), acc)
+        })
+    }
+}
+
+/// Like `kwlist!`, but produces a list of elements produced by any arbitrary expression
+///
+///     list!(atom!(foo), tuple!(atom!(bar), atom!(baz)))
+///
+/// Like `kwlist!`, this produces a proper list
+#[allow(unused_macros)]
+macro_rules! list {
+    ($($element:expr),*) => {
+        {
+            let mut elements = vec![$($element),*];
+            elements.reverse();
+            elements.iter().fold(nil!(), |acc, el| {
+                cons!(*el, acc)
+            })
+        }
+    }
+}
+
+/// A lower-level primitive for constructing lists, via cons cells.
+/// Given the following:
+///
+///     cons!(atom!(a), cons!(atom!(b), nil!()))
+///
+/// This is equivalent to `[a | [b | []]]`, which is in turn equivalent
+/// to `[a, b]`. You are better off using `list!` unless you explicitly
+/// need to construct an improper list
+#[allow(unused_macros)]
+macro_rules! cons {
+    ($head:expr, $tail:expr) => {
+        Expr::Cons(Cons {
+            span: ByteSpan::default(),
+            head: Box::new($head),
+            tail: Box::new($tail),
+        })
+    };
+}
+
+macro_rules! nil {
+    () => {
+        Expr::Nil(Nil(ByteSpan::default()))
+    };
+}
+
+/// Produces a tuple expression with the given elements
+macro_rules! tuple {
+    ($($element:expr),*) => {
+        Expr::Tuple(Tuple{
+            span: ByteSpan::default(),
+            elements: vec![$($element),*],
+        })
+    }
+}
+
+/// Produces an integer literal expression
+macro_rules! int {
+    ($i:expr) => {
+        Expr::Literal(Literal::Integer(ByteSpan::default(), $i))
+    };
+}
+
+/// Produces a literal expression which evaluates to an atom
+macro_rules! atom {
+    ($sym:ident) => {
+        Expr::Literal(Literal::Atom(Ident::with_empty_span(Symbol::intern(
+            stringify!($sym),
+        ))))
+    };
+    ($sym:expr) => {
+        Expr::Literal(Literal::Atom(Ident::with_empty_span(Symbol::intern($sym))))
+    };
+}
+
+macro_rules! atom_from_sym {
+    ($sym:expr) => {
+        Expr::Literal(Literal::Atom(Ident::with_empty_span($sym)))
+    };
+}
+
+/// Produces an Ident from an expression, meant to be used to simplify generating
+/// identifiers in the AST from strings or symbols
+macro_rules! ident {
+    ($sym:ident) => {
+        Ident::with_empty_span(Symbol::intern(stringify!($sym)))
+    };
+    ($sym:expr) => {
+        Ident::with_empty_span(Symbol::intern($sym))
+    };
+    (_) => {
+        Ident::with_empty_span(Symbol::intern("_"))
+    };
+}
+
+/// Produces an Option<Ident> from an expression, meant to be used to simplify generating
+/// identifiers in the AST from strings or symbols
+#[allow(unused_macros)]
+macro_rules! ident_opt {
+    ($sym:ident) => {
+        Some(Ident::with_empty_span(Symbol::intern(stringify!($sym))))
+    };
+    ($sym:expr) => {
+        Some(Ident::with_empty_span(Symbol::intern($sym)))
+    };
+    (_) => {
+        Ident::with_empty_span(Symbol::intern("_"))
+    };
+}
+
+/// Produces a variable expression
+macro_rules! var {
+    ($name:ident) => {
+        Expr::Var(ident!(stringify!($name)))
+    };
+    (_) => {
+        Expr::Var(ident!(_))
+    };
+}
+
+/// Produces a remote expression, e.g. `erlang:get_module_info`
+///
+/// Expects the module/function to be identifier symbols
+macro_rules! remote {
+    ($module:ident, $function:ident) => {
+        Expr::Remote(Remote {
+            span: ByteSpan::default(),
+            module: Box::new(atom!($module)),
+            function: Box::new(atom!($function)),
+        })
+    };
+    ($module:expr, $function:expr) => {
+        Expr::Remote(Remote {
+            span: ByteSpan::default(),
+            module: Box::new($module),
+            function: Box::new($function),
+        })
+    };
+}
+
+/// Produces a function application expression
+macro_rules! apply {
+    ($callee:expr, $($args:expr),*) => {
+        Expr::Apply(Apply {
+            span: ByteSpan::default(),
+            callee: Box::new($callee),
+            args: vec![$($args),*]
+        })
+    }
+}
+
+/// Produces a function definition
+macro_rules! fun {
+    ($name:ident ($($params:ident),*) -> $body:expr) => {
+        {
+            let params = vec![$(var!($params)),*];
+            let arity = params.len();
+            NamedFunction {
+                span: ByteSpan::default(),
+                name: ident!($name),
+                arity,
+                clauses: vec![
+                    FunctionClause{
+                        span: ByteSpan::default(),
+                        name: Some(ident!($name)),
+                        params,
+                        guard: None,
+                        body: vec![$body],
+                    }
+                ],
+                spec: None,
+            }
+        }
+    };
+    ($name:ident $(($($params:expr),*) -> $body:expr);*) => {
+        {
+            let mut clauses = Vec::new();
+            $(
+                clauses.push(FunctionClause {
+                    span: ByteSpan::default(),
+                    name: Some(ident!($name)),
+                    params: vec![$($params),*],
+                    guard: None,
+                    body: vec![$body],
+                });
+            )*
+            let arity = clauses.first().as_ref().unwrap().params.len();
+            NamedFunction {
+                span: ByteSpan::default(),
+                name: ident!($name),
+                arity,
+                clauses,
+                spec: None,
+            }
+        }
+    }
+}

--- a/frontend/src/parser/visitor.rs
+++ b/frontend/src/parser/visitor.rs
@@ -1,0 +1,674 @@
+///! Immutable/mutable visitors for Erlang AST
+
+/// Converts AST to a pretty printed source string.
+pub mod pretty_print;
+
+use std::collections::HashSet;
+
+use super::ast::*;
+
+pub use self::pretty_print::PrettyPrintVisitor;
+
+macro_rules! make_visitor {
+    ($visitor_trait_name:ident, $($mutability:ident)*) => {
+        #[cfg_attr(rustfmt, rustfmt_skip)]
+        pub trait $visitor_trait_name<'ast> {
+            // Override the following functions. The `walk` functions are the default behavior.
+
+            /// This is the initial function used to start traversing the AST. By default, this
+            /// will simply recursively walk down the AST without performing any meaningful action.
+            fn visit(&mut self, module: &'ast $($mutability)* Module) {
+                self.walk_module(module);
+            }
+
+            fn visit_imports(&mut self, _imports: &'ast $($mutability)* HashSet<ResolvedFunctionName>) {}
+            fn visit_exports(&mut self, _exports: &'ast $($mutability)* HashSet<ResolvedFunctionName>) {}
+            fn visit_exported_types(&mut self, _exported_types: &'ast $($mutability)* HashSet<ResolvedFunctionName>) {}
+            fn visit_behaviours(&mut self, _behaviours: &'ast $($mutability)* HashSet<Ident>) {}
+
+            fn visit_type_def(&mut self, type_def: &'ast $($mutability)* TypeDef) {
+                self.walk_type_def(type_def);
+            }
+
+            fn visit_record(&mut self, record: &'ast $($mutability)* Record) {
+                self.walk_record(record);
+            }
+
+            fn visit_record_field(&mut self, field: &'ast $($mutability)* RecordField) {
+                self.walk_record_field(field);
+            }
+
+            fn visit_callback(&mut self, callback: &'ast $($mutability)* Callback) {
+                self.walk_callback(callback);
+            }
+
+            fn visit_callback_signature(&mut self, sig: &'ast $($mutability)* TypeSig) {
+                self.walk_sig(sig);
+            }
+
+            fn visit_spec(&mut self, spec: &'ast $($mutability)* TypeSpec) {
+                self.walk_spec(spec);
+            }
+
+            fn visit_spec_signature(&mut self, sig: &'ast $($mutability)* TypeSig) {
+                self.walk_sig(sig);
+            }
+
+            fn visit_attribute(&mut self, attribute: &'ast $($mutability)* UserAttribute) {
+                self.walk_attribute(attribute);
+            }
+
+            fn visit_function(&mut self, function: &'ast $($mutability)* NamedFunction) {
+                self.walk_function(function);
+            }
+
+            fn visit_function_clause(&mut self, clause: &'ast $($mutability)* FunctionClause) {
+                self.walk_function_clause(clause);
+            }
+
+            fn visit_guard(&mut self, guard: &'ast $($mutability)* Guard) {
+                self.walk_guard(guard);
+            }
+
+            fn visit_type(&mut self, spec: &'ast $($mutability)* Type) {
+                self.walk_type(spec);
+            }
+
+            fn visit_type_guard(&mut self, guard: &'ast $($mutability)* TypeGuard) {
+                self.walk_type_guard(guard);
+            }
+
+            fn visit_expression(&mut self, expr: &'ast $($mutability)* Expr) {
+                match expr {
+                    &$($mutability)* Expr::Var(ref $($mutability)* expr) => self.visit_identifier(expr),
+                    &$($mutability)* Expr::Literal(ref $($mutability)* expr) => self.visit_literal(expr),
+                    &$($mutability)* Expr::FunctionName(ref $($mutability)* expr) => self.visit_function_name(expr),
+                    &$($mutability)* Expr::Nil(ref $($mutability)* expr) => self.visit_nil(expr),
+                    &$($mutability)* Expr::Cons(ref $($mutability)* expr) => self.visit_cons(expr),
+                    &$($mutability)* Expr::Tuple(ref $($mutability)* expr) => self.visit_tuple(expr),
+                    &$($mutability)* Expr::Map(ref $($mutability)* expr) => self.visit_map(expr),
+                    &$($mutability)* Expr::MapUpdate(ref $($mutability)* expr) => self.visit_map_update(expr),
+                    &$($mutability)* Expr::MapProjection(ref $($mutability)* expr) => self.visit_map_projection(expr),
+                    &$($mutability)* Expr::Binary(ref $($mutability)* expr) => self.visit_binary(expr),
+                    &$($mutability)* Expr::Record(ref $($mutability)* expr) => self.visit_record(expr),
+                    &$($mutability)* Expr::RecordAccess(ref $($mutability)* expr) => self.visit_record_access(expr),
+                    &$($mutability)* Expr::RecordIndex(ref $($mutability)* expr) => self.visit_record_index(expr),
+                    &$($mutability)* Expr::RecordUpdate(ref $($mutability)* expr) => self.visit_record_update(expr),
+                    &$($mutability)* Expr::ListComprehension(ref $($mutability)* expr) => self.visit_list_comprehension(expr),
+                    &$($mutability)* Expr::BinaryComprehension(ref $($mutability)* expr) => self.visit_binary_comprehension(expr),
+                    &$($mutability)* Expr::Generator(ref $($mutability)* expr) => self.visit_generator(expr),
+                    &$($mutability)* Expr::BinaryGenerator(ref $($mutability)* expr) => self.visit_binary_generator(expr),
+                    &$($mutability)* Expr::Begin(ref $($mutability)* expr) => self.visit_begin(expr),
+                    &$($mutability)* Expr::Apply(ref $($mutability)* expr) => self.visit_apply(expr),
+                    &$($mutability)* Expr::Remote(ref $($mutability)* expr) => self.visit_remote(expr),
+                    &$($mutability)* Expr::BinaryExpr(ref $($mutability)* expr) => self.visit_binary_expr(expr),
+                    &$($mutability)* Expr::UnaryExpr(ref $($mutability)* expr) => self.visit_unary_expr(expr),
+                    &$($mutability)* Expr::Match(ref $($mutability)* expr) => self.visit_match(expr),
+                    &$($mutability)* Expr::If(ref $($mutability)* expr) => self.visit_if(expr),
+                    &$($mutability)* Expr::Catch(ref $($mutability)* expr) => self.visit_catch(expr),
+                    &$($mutability)* Expr::Case(ref $($mutability)* expr) => self.visit_case(expr),
+                    &$($mutability)* Expr::Receive(ref $($mutability)* expr) => self.visit_receive(expr),
+                    &$($mutability)* Expr::Try(ref $($mutability)* expr) => self.visit_try(expr),
+                    &$($mutability)* Expr::Fun(ref $($mutability)* expr) => self.visit_fun(expr),
+                }
+            }
+
+            fn visit_name(&mut self, name: &'ast $($mutability)* Name) {
+                if let &$($mutability)* Name::Var(ref $($mutability)* var) = name {
+                    self.visit_identifier(var);
+                }
+            }
+
+            fn visit_identifier(&mut self, _identifier: &'ast $($mutability)* Ident) {}
+
+            fn visit_symbol(&mut self, _symbol: &'ast $($mutability)* Symbol) {}
+
+            fn visit_literal(&mut self, _literal: &'ast $($mutability)* Literal) {}
+
+            fn visit_function_name(&mut self, name: &'ast $($mutability)* FunctionName) {
+                self.walk_function_name(name);
+            }
+
+            fn visit_resolved_function_name(&mut self, _name: &'ast $($mutability)* ResolvedFunctionName) {}
+
+            fn visit_partially_resolved_function_name(&mut self, _name: &'ast $($mutability)* PartiallyResolvedFunctionName) {}
+
+            fn visit_unresolved_function_name(&mut self, name: &'ast $($mutability)* UnresolvedFunctionName) {
+                self.walk_unresolved_function_name(name);
+            }
+
+            fn visit_nil(&mut self, _nil: &'ast $($mutability)* Nil) {}
+
+            fn visit_cons(&mut self, cons: &'ast $($mutability)* Cons) {
+                self.walk_cons(cons);
+            }
+
+            fn visit_tuple(&mut self, tuple: &'ast $($mutability)* Tuple) {
+                self.walk_tuple(tuple);
+            }
+
+            fn visit_map(&mut self, map: &'ast $($mutability)* Map) {
+                self.walk_map(map);
+            }
+
+            fn visit_map_field(&mut self, field: &'ast $($mutability)* MapField) {
+                self.walk_map_field(field);
+            }
+
+            fn visit_map_update(&mut self, map: &'ast $($mutability)* MapUpdate) {
+                self.walk_map_update(map);
+            }
+
+            fn visit_map_projection(&mut self, map: &'ast $($mutability)* MapProjection) {
+                self.walk_map_projection(map);
+            }
+
+            fn visit_binary(&mut self, binary: &'ast $($mutability)* Binary) {
+                self.walk_binary(binary);
+            }
+
+            fn visit_binary_element(&mut self, element: &'ast $($mutability)* BinaryElement) {
+                self.walk_binary_element(element);
+            }
+
+            fn visit_bit_type(&mut self, _ty: &'ast $($mutability)* BitType) {}
+
+            fn visit_record_access(&mut self, ra: &'ast $($mutability)* RecordAccess) {
+                self.walk_record_access(ra);
+            }
+
+            fn visit_record_index(&mut self, _ri: &'ast $($mutability)* RecordIndex) {}
+
+            fn visit_record_update(&mut self, ru: &'ast $($mutability)* RecordUpdate) {
+                self.walk_record_update(ru);
+            }
+
+            fn visit_list_comprehension(&mut self, lc: &'ast $($mutability)* ListComprehension) {
+                self.walk_list_comprehension(lc);
+            }
+
+            fn visit_binary_comprehension(&mut self, bc: &'ast $($mutability)* BinaryComprehension) {
+                self.walk_binary_comprehension(bc);
+            }
+
+            fn visit_generator(&mut self, generator: &'ast $($mutability)* Generator) {
+                self.walk_generator(generator);
+            }
+
+            fn visit_binary_generator(&mut self, generator: &'ast $($mutability)* BinaryGenerator) {
+                self.walk_binary_generator(generator);
+            }
+
+            fn visit_begin(&mut self, begin: &'ast $($mutability)* Begin) {
+                self.walk_begin(begin);
+            }
+
+            fn visit_apply(&mut self, apply: &'ast $($mutability)* Apply) {
+                self.walk_apply(apply);
+            }
+
+            fn visit_remote(&mut self, remote: &'ast $($mutability)* Remote) {
+                self.walk_remote(remote);
+            }
+
+            fn visit_binary_expr(&mut self, expr: &'ast $($mutability)* BinaryExpr) {
+                self.walk_binary_expr(expr);
+            }
+
+            fn visit_unary_expr(&mut self, expr: &'ast $($mutability)* UnaryExpr) {
+                self.walk_unary_expr(expr);
+            }
+
+            fn visit_match(&mut self, expr: &'ast $($mutability)* Match) {
+                self.walk_match(expr);
+            }
+
+            fn visit_if(&mut self, expr: &'ast $($mutability)* If) {
+                self.walk_if(expr);
+            }
+
+            fn visit_if_clause(&mut self, expr: &'ast $($mutability)* IfClause) {
+                self.walk_if_clause(expr);
+            }
+
+            fn visit_catch(&mut self, expr: &'ast $($mutability)* Catch) {
+                self.walk_catch(expr);
+            }
+
+            fn visit_case(&mut self, expr: &'ast $($mutability)* Case) {
+                self.walk_case(expr);
+            }
+
+            fn visit_receive(&mut self, expr: &'ast $($mutability)* Receive) {
+                self.walk_receive(expr);
+            }
+
+            fn visit_after(&mut self, expr: &'ast $($mutability)* After) {
+                self.walk_after(expr);
+            }
+
+            fn visit_try(&mut self, expr: &'ast $($mutability)* Try) {
+                self.walk_try(expr);
+            }
+
+            fn visit_try_clause(&mut self, expr: &'ast $($mutability)* TryClause) {
+                self.walk_try_clause(expr);
+            }
+
+            fn visit_clause(&mut self, expr: &'ast $($mutability)* Clause) {
+                self.walk_clause(expr);
+            }
+
+            fn visit_fun(&mut self, expr: &'ast $($mutability)* Function) {
+                self.walk_fun(expr);
+            }
+
+            fn visit_lambda(&mut self, expr: &'ast $($mutability)* Lambda) {
+                self.walk_lambda(expr);
+            }
+
+            fn visit_named_lambda(&mut self, expr: &'ast $($mutability)* NamedFunction) {
+                self.walk_named_lambda(expr);
+            }
+
+            // The `walk` functions are not meant to be overridden.
+
+            fn walk_module(&mut self, module: &'ast $($mutability)* Module) {
+                self.visit_imports(&$($mutability)* module.imports);
+
+                self.visit_exports(&$($mutability)* module.exports);
+
+                for (_, type_def) in &$($mutability)* module.types {
+                    self.visit_type_def(type_def);
+                }
+
+                self.visit_exported_types(&$($mutability)* module.exported_types);
+
+                self.visit_behaviours(&$($mutability)* module.behaviours);
+
+                for (_, callback) in &$($mutability)* module.callbacks {
+                    self.visit_callback(callback);
+                }
+
+                for (_, record) in &$($mutability)* module.records {
+                    self.visit_record(record);
+                }
+
+                for (_, attribute) in &$($mutability)* module.attributes {
+                    self.visit_attribute(attribute);
+                }
+
+                for (_, function) in &$($mutability)* module.functions {
+                    self.visit_function(function);
+                }
+            }
+
+            fn walk_type_def(&mut self, type_def: &'ast $($mutability)* TypeDef) {
+                self.visit_type(&$($mutability)* type_def.ty);
+            }
+
+            fn walk_record(&mut self, record: &'ast $($mutability)* Record) {
+                for field in &$($mutability)* record.fields {
+                    self.visit_record_field(field);
+                }
+            }
+
+            fn walk_record_field(&mut self, field: &'ast $($mutability)* RecordField) {
+                self.visit_name(&$($mutability)* field.name);
+                if let Some(ref $($mutability)* expr) = field.value {
+                    self.visit_expression(expr);
+                }
+                if let Some(ref $($mutability)* ty) = field.ty {
+                    self.visit_type(ty);
+                }
+            }
+
+            fn walk_callback(&mut self, callback: &'ast $($mutability)* Callback) {
+                for sig in &$($mutability)* callback.sigs {
+                    self.visit_callback_signature(sig);
+                }
+            }
+
+            fn walk_spec(&mut self, spec: &'ast $($mutability)* TypeSpec) {
+                for sig in &$($mutability)* spec.sigs {
+                    self.visit_spec_signature(sig);
+                }
+            }
+
+            fn walk_sig(&mut self, sig: &'ast $($mutability)* TypeSig) {
+                for param in &$($mutability)* sig.params {
+                    self.visit_type(param);
+                }
+
+                self.visit_type(&$($mutability)* sig.ret);
+
+                match sig.guards {
+                    None => (),
+                    Some(ref $($mutability)* guards) => {
+                        for guard in guards {
+                            self.visit_type_guard(guard);
+                        }
+                    }
+                }
+            }
+
+            fn walk_attribute(&mut self, attribute: &'ast $($mutability)* UserAttribute) {
+                self.visit_expression(&$($mutability)* attribute.value);
+            }
+
+            fn walk_function(&mut self, function: &'ast $($mutability)* NamedFunction) {
+                for clause in &$($mutability)* function.clauses {
+                    self.visit_function_clause(clause);
+                }
+                match function.spec {
+                    None => (),
+                    Some(ref $($mutability)* spec) => self.visit_spec(spec)
+                }
+            }
+
+            fn walk_function_clause(&mut self, clause: &'ast $($mutability)* FunctionClause) {
+                for param in &$($mutability)* clause.params {
+                    self.visit_expression(param);
+                }
+
+                match clause.guard {
+                    None => (),
+                    Some(ref $($mutability)* guards) => {
+                        for guard in guards {
+                            self.visit_guard(guard);
+                        }
+                    }
+                }
+
+                for expr in &$($mutability)* clause.body {
+                    self.visit_expression(expr);
+                }
+            }
+
+            fn walk_guard(&mut self, guard: &'ast $($mutability)* Guard) {
+                for condition in &$($mutability)* guard.conditions {
+                    self.visit_expression(condition);
+                }
+            }
+
+            fn walk_type(&mut self, _ty: &'ast $($mutability)* Type) {}
+
+            fn walk_type_guard(&mut self, guard: &'ast $($mutability)* TypeGuard) {
+                self.visit_identifier(&$($mutability)* guard.var);
+                self.visit_type(&$($mutability)* guard.ty);
+            }
+
+
+            fn walk_function_name(&mut self, name: &'ast $($mutability)* FunctionName) {
+                match name {
+                    &$($mutability)* FunctionName::Resolved(ref $($mutability)* name) => {
+                        self.visit_resolved_function_name(name)
+                    }
+                    &$($mutability)* FunctionName::PartiallyResolved(ref $($mutability)* name) => {
+                        self.visit_partially_resolved_function_name(name)
+                    }
+                    &$($mutability)* FunctionName::Unresolved(ref $($mutability)* name) => {
+                        self.visit_unresolved_function_name(name)
+                    }
+                }
+            }
+
+            fn walk_unresolved_function_name(&mut self, name: &'ast $($mutability)* UnresolvedFunctionName) {
+                if let Some(ref $($mutability)* m) = name.module {
+                    self.visit_name(m);
+                }
+
+                self.visit_name(&$($mutability)* name.function);
+            }
+
+            fn walk_cons(&mut self, cons: &'ast $($mutability)* Cons) {
+                self.visit_expression(&$($mutability)* cons.head);
+                self.visit_expression(&$($mutability)* cons.tail);
+            }
+
+            fn walk_tuple(&mut self, tuple: &'ast $($mutability)* Tuple) {
+                for element in &$($mutability)* tuple.elements {
+                    self.visit_expression(element);
+                }
+            }
+
+            fn walk_map(&mut self, map: &'ast $($mutability)* Map) {
+                for field in &$($mutability)* map.fields {
+                    self.visit_map_field(field);
+                }
+            }
+
+            fn walk_map_field(&mut self, field: &'ast $($mutability)* MapField) {
+                match field {
+                    &$($mutability)* MapField::Assoc { ref $($mutability)* key, ref $($mutability)* value, .. } => {
+                        self.visit_expression(key);
+                        self.visit_expression(value);
+                    }
+                    &$($mutability)* MapField::Exact { ref $($mutability)* key, ref $($mutability)* value, .. } => {
+                        self.visit_expression(key);
+                        self.visit_expression(value);
+                    }
+                }
+            }
+
+            fn walk_map_update(&mut self, map: &'ast $($mutability)* MapUpdate) {
+                self.visit_expression(&$($mutability)* map.map);
+
+                for update in &$($mutability)* map.updates {
+                    self.visit_map_field(update);
+                }
+            }
+
+            fn walk_map_projection(&mut self, map: &'ast $($mutability)* MapProjection) {
+                self.visit_expression(&$($mutability)* map.map);
+
+                for field in &$($mutability)* map.fields {
+                    self.visit_map_field(field);
+                }
+            }
+
+            fn walk_binary(&mut self, bin: &'ast $($mutability)* Binary) {
+                for element in &$($mutability)* bin.elements {
+                    self.visit_binary_element(element);
+                }
+            }
+
+            fn walk_binary_element(&mut self, element: &'ast $($mutability)* BinaryElement) {
+                self.visit_expression(&$($mutability)* element.bit_expr);
+
+                if let Some(ref $($mutability)* expr) = element.bit_size {
+                    self.visit_expression(expr);
+                }
+
+                if let Some(ref $($mutability)* types) = element.bit_type {
+                    for ty in types {
+                        self.visit_bit_type(ty);
+                    }
+                }
+            }
+
+            fn walk_record_access(&mut self, ra: &'ast $($mutability)* RecordAccess) {
+                self.visit_expression(&$($mutability)* ra.record);
+            }
+
+            fn walk_record_update(&mut self, ru: &'ast $($mutability)* RecordUpdate) {
+                self.visit_expression(&$($mutability)* ru.record);
+                for update in &$($mutability)* ru.updates {
+                    self.visit_record_field(update);
+                }
+            }
+
+            fn walk_list_comprehension(&mut self, lc: &'ast $($mutability)* ListComprehension) {
+                self.visit_expression(&$($mutability)* lc.body);
+                for qualifier in &$($mutability)* lc.qualifiers {
+                    self.visit_expression(qualifier);
+                }
+            }
+
+            fn walk_binary_comprehension(&mut self, bc: &'ast $($mutability)* BinaryComprehension) {
+                self.visit_expression(&$($mutability)* bc.body);
+                for qualifier in &$($mutability)* bc.qualifiers {
+                    self.visit_expression(qualifier);
+                }
+            }
+
+            fn walk_generator(&mut self, generator: &'ast $($mutability)* Generator) {
+                self.visit_expression(&$($mutability)* generator.pattern);
+                self.visit_expression(&$($mutability)* generator.expr);
+            }
+
+            fn walk_binary_generator(&mut self, generator: &'ast $($mutability)* BinaryGenerator) {
+                self.visit_expression(&$($mutability)* generator.pattern);
+                self.visit_expression(&$($mutability)* generator.expr);
+            }
+
+            fn walk_begin(&mut self, begin: &'ast $($mutability)* Begin) {
+                for expr in &$($mutability)* begin.body {
+                    self.visit_expression(expr);
+                }
+            }
+
+            fn walk_apply(&mut self, apply: &'ast $($mutability)* Apply) {
+                self.visit_expression(&$($mutability)* apply.callee);
+                for arg in &$($mutability)* apply.args {
+                    self.visit_expression(arg);
+                }
+            }
+
+            fn walk_remote(&mut self, remote: &'ast $($mutability)* Remote) {
+                self.visit_expression(&$($mutability)* remote.module);
+                self.visit_expression(&$($mutability)* remote.function);
+            }
+
+            fn walk_binary_expr(&mut self, expr: &'ast $($mutability)* BinaryExpr) {
+                self.visit_expression(&$($mutability)* expr.lhs);
+                self.visit_expression(&$($mutability)* expr.rhs);
+            }
+
+            fn walk_unary_expr(&mut self, expr: &'ast $($mutability)* UnaryExpr) {
+                self.visit_expression(&$($mutability)* expr.operand);
+            }
+
+            fn walk_match(&mut self, expr: &'ast $($mutability)* Match) {
+                self.visit_expression(&$($mutability)* expr.pattern);
+                self.visit_expression(&$($mutability)* expr.expr);
+            }
+
+            fn walk_if(&mut self, expr: &'ast $($mutability)* If) {
+                for clause in &$($mutability)* expr.clauses {
+                    self.visit_if_clause(clause);
+                }
+            }
+
+            fn walk_if_clause(&mut self, clause: &'ast $($mutability)* IfClause) {
+                for condition in &$($mutability)* clause.conditions {
+                    self.visit_expression(condition);
+                }
+                for expr in &$($mutability)* clause.body {
+                    self.visit_expression(expr);
+                }
+            }
+
+            fn walk_catch(&mut self, expr: &'ast $($mutability)* Catch) {
+                self.visit_expression(&$($mutability)* expr.expr);
+            }
+
+            fn walk_case(&mut self, case: &'ast $($mutability)* Case) {
+                self.visit_expression(&$($mutability)* case.expr);
+
+                for clause in &$($mutability)* case.clauses {
+                    self.visit_clause(clause);
+                }
+            }
+
+            fn walk_receive(&mut self, receive: &'ast $($mutability)* Receive) {
+                if let Some(ref $($mutability)* clauses) = receive.clauses {
+                    for clause in clauses {
+                        self.visit_clause(clause);
+                    }
+                }
+                if let Some(ref $($mutability)* after) = receive.after {
+                    self.visit_after(after);
+                }
+            }
+
+            fn walk_after(&mut self, after: &'ast $($mutability)* After) {
+                self.visit_expression(&$($mutability)* after.timeout);
+                for expr in &$($mutability)* after.body {
+                    self.visit_expression(expr);
+                }
+            }
+
+            fn walk_try(&mut self, try_expr: &'ast $($mutability)* Try) {
+                if let Some(ref $($mutability)* exprs) = try_expr.exprs {
+                    for ex in exprs {
+                        self.visit_expression(ex);
+                    }
+                }
+                if let Some(ref $($mutability)* clauses) = try_expr.clauses {
+                    for clause in clauses {
+                        self.visit_clause(clause);
+                    }
+                }
+                if let Some(ref $($mutability)* catch_clauses) = try_expr.catch_clauses {
+                    for catch_clause in catch_clauses {
+                        self.visit_try_clause(catch_clause);
+                    }
+                }
+                if let Some(ref $($mutability)* after) = try_expr.after {
+                    for ex in after {
+                        self.visit_expression(ex);
+                    }
+                }
+            }
+
+            fn walk_try_clause(&mut self, clause: &'ast $($mutability)* TryClause) {
+                self.visit_name(&$($mutability)* clause.kind);
+                self.visit_expression(&$($mutability)* clause.error);
+                if let Some(ref $($mutability)* guards) = clause.guard {
+                    for guard in guards {
+                        self.visit_guard(guard);
+                    }
+                }
+                self.visit_identifier(&$($mutability)* clause.trace);
+                for expr in &$($mutability)* clause.body {
+                    self.visit_expression(expr);
+                }
+            }
+
+            fn walk_clause(&mut self, clause: &'ast $($mutability)* Clause) {
+                self.visit_expression(&$($mutability)* clause.pattern);
+                if let Some(ref $($mutability)* guards) = clause.guard {
+                    for guard in guards {
+                        self.visit_guard(guard);
+                    }
+                }
+                for expr in &$($mutability)* clause.body {
+                    self.visit_expression(expr);
+                }
+            }
+
+            fn walk_fun(&mut self, fun: &'ast $($mutability)* Function) {
+                match fun {
+                    Function::Named(ref $($mutability)* named) => self.visit_named_lambda(named),
+                    Function::Unnamed(ref $($mutability)* lambda) => self.visit_lambda(lambda),
+                }
+            }
+
+            fn walk_lambda(&mut self, lambda: &'ast $($mutability)* Lambda) {
+                for clause in &$($mutability)* lambda.clauses {
+                    self.visit_function_clause(clause);
+                }
+            }
+
+            fn walk_named_lambda(&mut self, lambda: &'ast $($mutability)* NamedFunction) {
+                for clause in &$($mutability)* lambda.clauses {
+                    self.visit_function_clause(clause);
+                }
+            }
+        }
+    }
+}
+
+make_visitor!(ImmutableVisitor,);
+make_visitor!(MutableVisitor, mut);

--- a/frontend/src/parser/visitor/pretty_print.rs
+++ b/frontend/src/parser/visitor/pretty_print.rs
@@ -1,0 +1,36 @@
+use crate::parser::ast::*;
+
+use super::ImmutableVisitor;
+
+/// A visitor that can be used to convert an AST back into source code.
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+pub struct PrettyPrintVisitor {
+    output: String,
+}
+
+impl PrettyPrintVisitor {
+    pub fn new() -> Self {
+        PrettyPrintVisitor {
+            output: String::new(),
+        }
+    }
+
+    pub fn get_output(&self) -> &String {
+        &self.output
+    }
+
+    fn stringify_atom(&self, atom: &Ident) -> String {
+        atom.name.as_str().get().to_owned()
+    }
+}
+
+impl<'ast> ImmutableVisitor<'ast> for PrettyPrintVisitor {
+    fn visit(&mut self, module: &'ast Module) {
+        self.output.push_str(&format!(
+            "-module({}).\n\n",
+            self.stringify_atom(&module.name)
+        ));
+
+        // TODO
+    }
+}

--- a/frontend/src/preprocessor.rs
+++ b/frontend/src/preprocessor.rs
@@ -1,0 +1,24 @@
+mod directive;
+mod errors;
+mod evaluator;
+mod macros;
+mod preprocessor;
+mod token_reader;
+mod token_stream;
+
+pub mod directives;
+pub mod types;
+
+pub use self::directive::Directive;
+pub use self::errors::PreprocessorError;
+pub use self::macros::{MacroCall, MacroDef};
+pub use self::preprocessor::Preprocessor;
+
+use diagnostics::ByteIndex;
+
+use crate::lexer::Token;
+
+/// The result produced by the preprocessor
+pub type Preprocessed = std::result::Result<(ByteIndex, Token, ByteIndex), PreprocessorError>;
+
+type Result<T> = std::result::Result<T, PreprocessorError>;

--- a/frontend/src/preprocessor/directive.rs
+++ b/frontend/src/preprocessor/directive.rs
@@ -1,0 +1,179 @@
+use std::fmt;
+
+use diagnostics::ByteSpan;
+
+use crate::lexer::{AtomToken, LexicalToken, SymbolToken, Token};
+
+use super::Result;
+
+use super::directives;
+use super::token_reader::{ReadFrom, TokenReader};
+
+/// Macro directive
+#[derive(Debug, Clone)]
+pub enum Directive {
+    Module(directives::Module),
+    Include(directives::Include),
+    IncludeLib(directives::IncludeLib),
+    Define(directives::Define),
+    Undef(directives::Undef),
+    Ifdef(directives::Ifdef),
+    Ifndef(directives::Ifndef),
+    If(directives::If),
+    Else(directives::Else),
+    Elif(directives::Elif),
+    Endif(directives::Endif),
+    Error(directives::Error),
+    Warning(directives::Warning),
+}
+impl Directive {
+    pub fn span(&self) -> ByteSpan {
+        match *self {
+            Directive::Module(ref t) => t.span(),
+            Directive::Include(ref t) => t.span(),
+            Directive::IncludeLib(ref t) => t.span(),
+            Directive::Define(ref t) => t.span(),
+            Directive::Undef(ref t) => t.span(),
+            Directive::Ifdef(ref t) => t.span(),
+            Directive::Ifndef(ref t) => t.span(),
+            Directive::If(ref t) => t.span(),
+            Directive::Else(ref t) => t.span(),
+            Directive::Elif(ref t) => t.span(),
+            Directive::Endif(ref t) => t.span(),
+            Directive::Error(ref t) => t.span(),
+            Directive::Warning(ref t) => t.span(),
+        }
+    }
+}
+impl fmt::Display for Directive {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Directive::Module(ref t) => t.fmt(f),
+            Directive::Include(ref t) => t.fmt(f),
+            Directive::IncludeLib(ref t) => t.fmt(f),
+            Directive::Define(ref t) => t.fmt(f),
+            Directive::Undef(ref t) => t.fmt(f),
+            Directive::Ifdef(ref t) => t.fmt(f),
+            Directive::Ifndef(ref t) => t.fmt(f),
+            Directive::If(ref t) => t.fmt(f),
+            Directive::Else(ref t) => t.fmt(f),
+            Directive::Elif(ref t) => t.fmt(f),
+            Directive::Endif(ref t) => t.fmt(f),
+            Directive::Error(ref t) => t.fmt(f),
+            Directive::Warning(ref t) => t.fmt(f),
+        }
+    }
+}
+impl ReadFrom for Directive {
+    fn try_read_from<R, S>(reader: &mut R) -> Result<Option<Self>>
+    where
+        R: TokenReader<Source = S>,
+    {
+        let _hyphen: SymbolToken = if let Some(_hyphen) = reader.try_read_expected(&Token::Minus)? {
+            _hyphen
+        } else {
+            return Ok(None);
+        };
+
+        let name: AtomToken = if let Some(name) = reader.try_read()? {
+            name
+        } else {
+            reader.unread_token(_hyphen.into());
+            return Ok(None);
+        };
+
+        let name_sym = name.symbol().as_str().get();
+        // Replace atoms with more concrete tokens for special attributes,
+        // but otherwise do nothing else with them
+        match name_sym {
+            "compile" => {
+                reader.unread_token(LexicalToken(name.0, Token::Record, name.2));
+                reader.unread_token(_hyphen.into());
+                return Ok(None);
+            }
+            "record" => {
+                reader.unread_token(LexicalToken(name.0, Token::Record, name.2));
+                reader.unread_token(_hyphen.into());
+                return Ok(None);
+            }
+            "spec" => {
+                reader.unread_token(LexicalToken(name.0, Token::Spec, name.2));
+                reader.unread_token(_hyphen.into());
+                return Ok(None);
+            }
+            "callback" => {
+                reader.unread_token(LexicalToken(name.0, Token::Callback, name.2));
+                reader.unread_token(_hyphen.into());
+                return Ok(None);
+            }
+            "optional_callback" => {
+                reader.unread_token(LexicalToken(name.0, Token::OptionalCallback, name.2));
+                reader.unread_token(_hyphen.into());
+                return Ok(None);
+            }
+            "import" => {
+                reader.unread_token(LexicalToken(name.0, Token::Import, name.2));
+                reader.unread_token(_hyphen.into());
+                return Ok(None);
+            }
+            "export" => {
+                reader.unread_token(LexicalToken(name.0, Token::Export, name.2));
+                reader.unread_token(_hyphen.into());
+                return Ok(None);
+            }
+            "export_type" => {
+                reader.unread_token(LexicalToken(name.0, Token::ExportType, name.2));
+                reader.unread_token(_hyphen.into());
+                return Ok(None);
+            }
+            "vsn" => {
+                reader.unread_token(LexicalToken(name.0, Token::Vsn, name.2));
+                reader.unread_token(_hyphen.into());
+                return Ok(None);
+            }
+            "on_load" => {
+                reader.unread_token(LexicalToken(name.0, Token::OnLoad, name.2));
+                reader.unread_token(_hyphen.into());
+                return Ok(None);
+            }
+            "behaviour" => {
+                reader.unread_token(LexicalToken(name.0, Token::Behaviour, name.2));
+                reader.unread_token(_hyphen.into());
+                return Ok(None);
+            }
+            "deprecated" => {
+                reader.unread_token(LexicalToken(name.0, Token::Deprecated, name.2));
+                reader.unread_token(_hyphen.into());
+                return Ok(None);
+            }
+            "type" => {
+                reader.unread_token(LexicalToken(name.0, Token::Type, name.2));
+                reader.unread_token(_hyphen.into());
+                return Ok(None);
+            }
+            _ => {
+                reader.unread_token(name.clone().into());
+                reader.unread_token(_hyphen.into());
+            }
+        }
+
+        match name.symbol().as_str().get() {
+            // -module(name) is treated as equivalent to -define(?MODULE, name)
+            "module" => reader.read().map(Directive::Module).map(Some),
+            // Actual preprocessor directives
+            "include" => reader.read().map(Directive::Include).map(Some),
+            "include_lib" => reader.read().map(Directive::IncludeLib).map(Some),
+            "define" => reader.read().map(Directive::Define).map(Some),
+            "undef" => reader.read().map(Directive::Undef).map(Some),
+            "ifdef" => reader.read().map(Directive::Ifdef).map(Some),
+            "ifndef" => reader.read().map(Directive::Ifndef).map(Some),
+            "if" => reader.read().map(Directive::If).map(Some),
+            "else" => reader.read().map(Directive::Else).map(Some),
+            "elif" => reader.read().map(Directive::Elif).map(Some),
+            "endif" => reader.read().map(Directive::Endif).map(Some),
+            "error" => reader.read().map(Directive::Error).map(Some),
+            "warning" => reader.read().map(Directive::Warning).map(Some),
+            _ => Ok(None),
+        }
+    }
+}

--- a/frontend/src/preprocessor/directives.rs
+++ b/frontend/src/preprocessor/directives.rs
@@ -1,0 +1,681 @@
+use std::collections::VecDeque;
+use std::fmt;
+use std::path::{Component, Path, PathBuf};
+
+use diagnostics::ByteSpan;
+use glob::glob;
+
+use crate::lexer::{symbols, Lexed, LexicalToken, Symbol, Token};
+use crate::lexer::{AtomToken, StringToken, SymbolToken};
+use crate::util;
+
+use super::token_reader::{ReadFrom, TokenReader};
+use super::types::{MacroName, MacroVariables};
+use super::{PreprocessorError, Result};
+
+/// `module` directive.
+///
+/// Not really a directive, but we need it for the ?MODULE macro
+#[derive(Debug, Clone)]
+pub struct Module {
+    pub _hyphen: SymbolToken,
+    pub _module: AtomToken,
+    pub _open_paren: SymbolToken,
+    pub name: AtomToken,
+    pub _close_paren: SymbolToken,
+    pub _dot: SymbolToken,
+}
+impl Module {
+    pub fn span(&self) -> ByteSpan {
+        let start = self._hyphen.0;
+        let end = self._dot.2;
+        ByteSpan::new(start, end)
+    }
+
+    pub fn expand(&self) -> VecDeque<LexicalToken> {
+        let mod_span = self._module.span();
+        vec![
+            self._hyphen.clone().into(),
+            LexicalToken(mod_span.start(), Token::Module, mod_span.end()),
+            self._open_paren.clone().into(),
+            self.name.clone().into(),
+            self._close_paren.clone().into(),
+            self._dot.clone().into(),
+        ]
+        .into()
+    }
+}
+impl fmt::Display for Module {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "-module({}).", self.name.symbol())
+    }
+}
+impl ReadFrom for Module {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        Ok(Module {
+            _hyphen: reader.read_expected(&Token::Minus)?,
+            _module: reader.read_expected(&symbols::Module)?,
+            _open_paren: reader.read_expected(&Token::LParen)?,
+            name: reader.read()?,
+            _close_paren: reader.read_expected(&Token::RParen)?,
+            _dot: reader.read_expected(&Token::Dot)?,
+        })
+    }
+}
+
+/// `include` directive.
+///
+/// See [9.1 File Inclusion](http://erlang.org/doc/reference_manual/macros.html#id85412)
+/// for detailed information.
+#[derive(Debug, Clone)]
+pub struct Include {
+    pub _hyphen: SymbolToken,
+    pub _include: AtomToken,
+    pub _open_paren: SymbolToken,
+    pub path: StringToken,
+    pub _close_paren: SymbolToken,
+    pub _dot: SymbolToken,
+}
+impl Include {
+    /// Executes file inclusion.
+    pub fn include(&self) -> PathBuf {
+        Path::new(&self.path.symbol().as_str().get()).to_path_buf()
+    }
+
+    pub fn span(&self) -> ByteSpan {
+        let start = self._hyphen.0;
+        let end = self._dot.2;
+        ByteSpan::new(start, end)
+    }
+}
+impl fmt::Display for Include {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "-include({}).", self.path.symbol())
+    }
+}
+impl ReadFrom for Include {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        Ok(Include {
+            _hyphen: reader.read_expected(&Token::Minus)?,
+            _include: reader.read_expected(&symbols::Include)?,
+            _open_paren: reader.read_expected(&Token::LParen)?,
+            path: reader.read()?,
+            _close_paren: reader.read_expected(&Token::RParen)?,
+            _dot: reader.read_expected(&Token::Dot)?,
+        })
+    }
+}
+
+/// `include_lib` directive.
+///
+/// See [9.1 File Inclusion](http://erlang.org/doc/reference_manual/macros.html#id85412)
+/// for detailed information.
+#[derive(Debug, Clone)]
+#[allow(missing_docs)]
+pub struct IncludeLib {
+    pub _hyphen: SymbolToken,
+    pub _include_lib: AtomToken,
+    pub _open_paren: SymbolToken,
+    pub path: StringToken,
+    pub _close_paren: SymbolToken,
+    pub _dot: SymbolToken,
+}
+impl IncludeLib {
+    /// Executes file inclusion.
+    pub fn include_lib(&self, code_paths: &VecDeque<PathBuf>) -> Result<PathBuf> {
+        let mut path = match util::substitute_path_variables(self.path.symbol().as_str().get()) {
+            Ok(path) => path,
+            Err(err) => return Err(err.into()),
+        };
+
+        let temp_path = path.clone();
+        let mut components = temp_path.components();
+        if let Some(Component::Normal(app_name)) = components.next() {
+            let app_name = app_name
+                .to_str()
+                .expect("internal error: expected app name here");
+            let pattern = format!("{}-*", app_name);
+            'root: for root in code_paths.iter() {
+                let pattern = root.join(&pattern);
+                let pattern = pattern.to_str().unwrap();
+                if let Some(entry) = glob(pattern).map_err(PreprocessorError::from)?.nth(0) {
+                    path = entry.map_err(PreprocessorError::from)?;
+                    for c in components {
+                        path.push(c.as_os_str());
+                    }
+                    break 'root;
+                }
+            }
+        }
+        Ok(path)
+    }
+
+    pub fn span(&self) -> ByteSpan {
+        let start = self._hyphen.0;
+        let end = self._dot.2;
+        ByteSpan::new(start, end)
+    }
+}
+impl fmt::Display for IncludeLib {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "-include_lib({}).", self.path.symbol())
+    }
+}
+impl ReadFrom for IncludeLib {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        Ok(IncludeLib {
+            _hyphen: reader.read_expected(&Token::Minus)?,
+            _include_lib: reader.read_expected(&symbols::IncludeLib)?,
+            _open_paren: reader.read_expected(&Token::LParen)?,
+            path: reader.read()?,
+            _close_paren: reader.read_expected(&Token::RParen)?,
+            _dot: reader.read_expected(&Token::Dot)?,
+        })
+    }
+}
+
+/// `error` directive.
+///
+/// See [9.6 -error() and -warning() directives][error_and_warning]
+/// for detailed information.
+///
+/// [error_and_warning]: http://erlang.org/doc/reference_manual/macros.html#id85997
+#[derive(Debug, Clone)]
+pub struct Error {
+    pub _hyphen: SymbolToken,
+    pub _error: AtomToken,
+    pub _open_paren: SymbolToken,
+    pub message: StringToken,
+    pub _close_paren: SymbolToken,
+    pub _dot: SymbolToken,
+}
+impl Error {
+    pub fn span(&self) -> ByteSpan {
+        let start = self._hyphen.0;
+        let end = self._dot.2;
+        ByteSpan::new(start, end)
+    }
+}
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "-error({}).", self.message.symbol())
+    }
+}
+impl ReadFrom for Error {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        Ok(Error {
+            _hyphen: reader.read_expected(&Token::Minus)?,
+            _error: reader.read_expected(&symbols::Error)?,
+            _open_paren: reader.read_expected(&Token::LParen)?,
+            message: reader.read()?,
+            _close_paren: reader.read_expected(&Token::RParen)?,
+            _dot: reader.read_expected(&Token::Dot)?,
+        })
+    }
+}
+
+/// `warning` directive.
+///
+/// See [9.6 -error() and -warning() directives][error_and_warning]
+/// for detailed information.
+///
+/// [error_and_warning]: http://erlang.org/doc/reference_manual/macros.html#id85997
+#[derive(Debug, Clone)]
+pub struct Warning {
+    pub _hyphen: SymbolToken,
+    pub _warning: AtomToken,
+    pub _open_paren: SymbolToken,
+    pub message: StringToken,
+    pub _close_paren: SymbolToken,
+    pub _dot: SymbolToken,
+}
+impl Warning {
+    pub fn span(&self) -> ByteSpan {
+        let start = self._hyphen.0;
+        let end = self._dot.2;
+        ByteSpan::new(start, end)
+    }
+}
+impl fmt::Display for Warning {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "-warning({}).", self.message.symbol())
+    }
+}
+impl ReadFrom for Warning {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        Ok(Warning {
+            _hyphen: reader.read_expected(&Token::Minus)?,
+            _warning: reader.read_expected(&symbols::Warning)?,
+            _open_paren: reader.read_expected(&Token::LParen)?,
+            message: reader.read()?,
+            _close_paren: reader.read_expected(&Token::RParen)?,
+            _dot: reader.read_expected(&Token::Dot)?,
+        })
+    }
+}
+
+/// `endif` directive.
+///
+/// See [9.5 Flow Control in Macros][flow_control] for detailed information.
+///
+/// [flow_control]: http://erlang.org/doc/reference_manual/macros.html#id85859
+#[derive(Debug, Clone)]
+pub struct Endif {
+    pub _hyphen: SymbolToken,
+    pub _endif: AtomToken,
+    pub _dot: SymbolToken,
+}
+impl Endif {
+    pub fn span(&self) -> ByteSpan {
+        let start = self._hyphen.0;
+        let end = self._dot.2;
+        ByteSpan::new(start, end)
+    }
+}
+impl fmt::Display for Endif {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "-endif.")
+    }
+}
+impl ReadFrom for Endif {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        Ok(Endif {
+            _hyphen: reader.read_expected(&Token::Minus)?,
+            _endif: reader.read_expected(&symbols::Endif)?,
+            _dot: reader.read_expected(&Token::Dot)?,
+        })
+    }
+}
+
+/// `else` directive.
+///
+/// See [9.5 Flow Control in Macros][flow_control] for detailed information.
+///
+/// [flow_control]: http://erlang.org/doc/reference_manual/macros.html#id85859
+#[derive(Debug, Clone)]
+pub struct Else {
+    pub _hyphen: SymbolToken,
+    pub _else: AtomToken,
+    pub _dot: SymbolToken,
+}
+impl Else {
+    pub fn span(&self) -> ByteSpan {
+        let start = self._hyphen.0;
+        let end = self._dot.2;
+        ByteSpan::new(start, end)
+    }
+}
+impl fmt::Display for Else {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "-else.")
+    }
+}
+impl ReadFrom for Else {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        Ok(Else {
+            _hyphen: reader.read_expected(&Token::Minus)?,
+            _else: reader.read_expected(&symbols::Else)?,
+            _dot: reader.read_expected(&Token::Dot)?,
+        })
+    }
+}
+
+/// `undef` directive.
+///
+/// See [9.5 Flow Control in Macros][flow_control] for detailed information.
+///
+/// [flow_control]: http://erlang.org/doc/reference_manual/macros.html#id85859
+#[derive(Debug, Clone)]
+pub struct Undef {
+    pub _hyphen: SymbolToken,
+    pub _undef: AtomToken,
+    pub _open_paren: SymbolToken,
+    pub name: MacroName,
+    pub _close_paren: SymbolToken,
+    pub _dot: SymbolToken,
+}
+impl Undef {
+    pub fn span(&self) -> ByteSpan {
+        let start = self._hyphen.0;
+        let end = self._dot.2;
+        ByteSpan::new(start, end)
+    }
+    pub fn name(&self) -> Symbol {
+        self.name.symbol()
+    }
+}
+impl fmt::Display for Undef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "-undef({}).", self.name.symbol())
+    }
+}
+impl ReadFrom for Undef {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        Ok(Undef {
+            _hyphen: reader.read_expected(&Token::Minus)?,
+            _undef: reader.read_expected(&symbols::Undef)?,
+            _open_paren: reader.read_expected(&Token::LParen)?,
+            name: reader.read()?,
+            _close_paren: reader.read_expected(&Token::RParen)?,
+            _dot: reader.read_expected(&Token::Dot)?,
+        })
+    }
+}
+
+/// `if` directive.
+///
+/// See [9.5 Flow Control in Macros][flow_control] for detailed information.
+///
+/// [flow_control]: http://erlang.org/doc/reference_manual/macros.html#id85859
+#[derive(Debug, Clone)]
+pub struct If {
+    pub _hyphen: SymbolToken,
+    pub _if: AtomToken,
+    pub _open_paren: SymbolToken,
+    pub condition: VecDeque<Lexed>,
+    pub _close_paren: SymbolToken,
+    pub _dot: SymbolToken,
+}
+impl If {
+    pub fn span(&self) -> ByteSpan {
+        let start = self._hyphen.0;
+        let end = self._dot.2;
+        ByteSpan::new(start, end)
+    }
+}
+impl fmt::Display for If {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "-if({:?}).", self.condition)
+    }
+}
+impl ReadFrom for If {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        Ok(If {
+            _hyphen: reader.read_expected(&Token::Minus)?,
+            _if: reader.read_expected(&symbols::If)?,
+            _open_paren: reader.read_expected(&Token::LParen)?,
+            condition: read_condition(reader)?,
+            _close_paren: reader.read_expected(&Token::RParen)?,
+            _dot: reader.read_expected(&Token::Dot)?,
+        })
+    }
+}
+
+/// `elif` directive.
+///
+/// See [9.5 Flow Control in Macros][flow_control] for detailed information.
+///
+/// [flow_control]: http://erlang.org/doc/reference_manual/macros.html#id85859
+#[derive(Debug, Clone)]
+pub struct Elif {
+    pub _hyphen: SymbolToken,
+    pub _elif: AtomToken,
+    pub _open_paren: SymbolToken,
+    pub condition: VecDeque<Lexed>,
+    pub _close_paren: SymbolToken,
+    pub _dot: SymbolToken,
+}
+impl Elif {
+    pub fn span(&self) -> ByteSpan {
+        let start = self._hyphen.0;
+        let end = self._dot.2;
+        ByteSpan::new(start, end)
+    }
+}
+impl fmt::Display for Elif {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "-elif({:?}).", self.condition)
+    }
+}
+impl ReadFrom for Elif {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        Ok(Elif {
+            _hyphen: reader.read_expected(&Token::Minus)?,
+            _elif: reader.read_expected(&symbols::Elif)?,
+            _open_paren: reader.read_expected(&Token::LParen)?,
+            condition: read_condition(reader)?,
+            _close_paren: reader.read_expected(&Token::RParen)?,
+            _dot: reader.read_expected(&Token::Dot)?,
+        })
+    }
+}
+
+fn read_condition<R, S>(reader: &mut R) -> Result<VecDeque<Lexed>>
+where
+    R: TokenReader<Source = S>,
+{
+    let mut open = 0;
+    let mut condition = VecDeque::new();
+
+    loop {
+        match reader.try_read_token()? {
+            None => return Err(PreprocessorError::UnexpectedEOF),
+            Some(token) => match token {
+                LexicalToken(_, Token::LParen, _) => {
+                    open = open + 1;
+                    condition.push_back(Ok(token));
+                }
+                LexicalToken(_, Token::RParen, _) if open == 0 => {
+                    reader.unread_token(token);
+                    break;
+                }
+                LexicalToken(_, Token::RParen, _) => {
+                    open = open - 1;
+                    condition.push_back(Ok(token));
+                }
+                _ => {
+                    condition.push_back(Ok(token));
+                }
+            },
+        }
+    }
+
+    Ok(condition)
+}
+
+/// `ifdef` directive.
+///
+/// See [9.5 Flow Control in Macros][flow_control] for detailed information.
+///
+/// [flow_control]: http://erlang.org/doc/reference_manual/macros.html#id85859
+#[derive(Debug, Clone)]
+pub struct Ifdef {
+    pub _hyphen: SymbolToken,
+    pub _ifdef: AtomToken,
+    pub _open_paren: SymbolToken,
+    pub name: MacroName,
+    pub _close_paren: SymbolToken,
+    pub _dot: SymbolToken,
+}
+impl Ifdef {
+    pub fn span(&self) -> ByteSpan {
+        let start = self._hyphen.0;
+        let end = self._dot.2;
+        ByteSpan::new(start, end)
+    }
+    pub fn name(&self) -> Symbol {
+        self.name.symbol()
+    }
+}
+impl fmt::Display for Ifdef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "-ifdef({}).", self.name.symbol())
+    }
+}
+impl ReadFrom for Ifdef {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        Ok(Ifdef {
+            _hyphen: reader.read_expected(&Token::Minus)?,
+            _ifdef: reader.read_expected(&symbols::Ifdef)?,
+            _open_paren: reader.read_expected(&Token::LParen)?,
+            name: reader.read()?,
+            _close_paren: reader.read_expected(&Token::RParen)?,
+            _dot: reader.read_expected(&Token::Dot)?,
+        })
+    }
+}
+
+/// `ifndef` directive.
+///
+/// See [9.5 Flow Control in Macros][flow_control] for detailed information.
+///
+/// [flow_control]: http://erlang.org/doc/reference_manual/macros.html#id85859
+#[derive(Debug, Clone)]
+pub struct Ifndef {
+    pub _hyphen: SymbolToken,
+    pub _ifndef: AtomToken,
+    pub _open_paren: SymbolToken,
+    pub name: MacroName,
+    pub _close_paren: SymbolToken,
+    pub _dot: SymbolToken,
+}
+impl Ifndef {
+    pub fn span(&self) -> ByteSpan {
+        let start = self._hyphen.0;
+        let end = self._dot.2;
+        ByteSpan::new(start, end)
+    }
+    pub fn name(&self) -> Symbol {
+        self.name.symbol()
+    }
+}
+impl fmt::Display for Ifndef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "-ifndef({}).", self.name.symbol())
+    }
+}
+impl ReadFrom for Ifndef {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        Ok(Ifndef {
+            _hyphen: reader.read_expected(&Token::Minus)?,
+            _ifndef: reader.read_expected(&symbols::Ifndef)?,
+            _open_paren: reader.read_expected(&Token::LParen)?,
+            name: reader.read()?,
+            _close_paren: reader.read_expected(&Token::RParen)?,
+            _dot: reader.read_expected(&Token::Dot)?,
+        })
+    }
+}
+
+/// `define` directive.
+///
+/// See [9.2 Defining and Using Macros][define_and_use] for detailed information.
+///
+/// [define_and_use]: http://erlang.org/doc/reference_manual/macros.html#id85572
+#[derive(Debug, Clone)]
+pub struct Define {
+    pub _hyphen: SymbolToken,
+    pub _define: AtomToken,
+    pub _open_paren: SymbolToken,
+    pub name: MacroName,
+    pub variables: Option<MacroVariables>,
+    pub _comma: SymbolToken,
+    pub replacement: Vec<LexicalToken>,
+    pub _close_paren: SymbolToken,
+    pub _dot: SymbolToken,
+}
+impl Define {
+    pub fn span(&self) -> ByteSpan {
+        let start = self._hyphen.0;
+        let end = self._dot.0;
+        ByteSpan::new(start, end)
+    }
+}
+impl fmt::Display for Define {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "-define({}{}, {}).",
+            self.name,
+            self.variables
+                .as_ref()
+                .map_or("".to_string(), |v| v.to_string(),),
+            self.replacement
+                .iter()
+                .map(|t| t.to_string())
+                .collect::<String>()
+        )
+    }
+}
+impl ReadFrom for Define {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        let _hyphen = reader.read_expected(&Token::Minus)?;
+        let _define = reader.read_expected(&symbols::Define)?;
+        let _open_paren = reader.read_expected(&Token::LParen)?;
+        let name = reader.read()?;
+        let variables =
+            if let Some(token) = reader.try_read_expected::<SymbolToken>(&Token::LParen)? {
+                reader.unread_token(token.into());
+                Some(reader.read()?)
+            } else {
+                None
+            };
+        let _comma = reader.read_expected(&Token::Comma)?;
+
+        let mut replacement = Vec::new();
+        loop {
+            if let Some(_close_paren) = reader.try_read_expected(&Token::RParen)? {
+                if let Some(_dot) = reader.try_read_expected(&Token::Dot)? {
+                    return Ok(Define {
+                        _hyphen,
+                        _define,
+                        _open_paren,
+                        name,
+                        variables,
+                        _comma,
+                        replacement,
+                        _close_paren,
+                        _dot,
+                    });
+                }
+                replacement.push(_close_paren.into());
+            } else {
+                match reader.read_token()? {
+                    token @ LexicalToken(_, Token::Dot, _) => {
+                        return Err(PreprocessorError::UnexpectedToken(token, Vec::new()));
+                    }
+                    token => replacement.push(token),
+                }
+            }
+        }
+    }
+}

--- a/frontend/src/preprocessor/errors.rs
+++ b/frontend/src/preprocessor/errors.rs
@@ -1,0 +1,207 @@
+use std;
+
+use diagnostics::{ByteSpan, Diagnostic, Label};
+use failure::{Error, Fail};
+use glob;
+use itertools::Itertools;
+
+use crate::lexer::SourceError;
+use crate::lexer::{LexicalError, LexicalToken, TokenConvertError};
+
+use crate::parser::ParserError;
+
+use super::directive::Directive;
+use super::macros::{MacroCall, MacroDef, Stringify};
+
+#[derive(Fail, Debug)]
+pub enum PreprocessorError {
+    #[fail(display = "{}", _0)]
+    Lexical(#[fail(cause)] LexicalError),
+
+    #[fail(display = "{}", _0)]
+    Source(#[fail(cause)] SourceError),
+
+    #[fail(display = "unable to parse constant expression")]
+    ParseError(ByteSpan, Vec<ParserError>),
+
+    #[fail(display = "{}", _1)]
+    CompilerError(Option<ByteSpan>, String),
+
+    #[fail(display = "invalid constant expression found in preprocessor directive")]
+    InvalidConstExpression(ByteSpan),
+
+    #[fail(display = "invalid conditional expression")]
+    InvalidConditional(ByteSpan),
+
+    #[fail(display = "call to builtin function failed")]
+    BuiltinFailed(ByteSpan, #[fail(cause)] Error),
+
+    #[fail(display = "found orphaned '-end.' directive")]
+    OrphanedEnd(Directive),
+
+    #[fail(display = "found orphaned '-else.' directive")]
+    OrphanedElse(Directive),
+
+    #[fail(display = "undefined macro")]
+    UndefinedStringifyMacro(Stringify),
+
+    #[fail(display = "undefined macro")]
+    UndefinedMacro(MacroCall),
+
+    #[fail(display = "invalid macro invocation")]
+    BadMacroCall(MacroCall, MacroDef, String),
+
+    #[fail(display = "i/o failure")]
+    IO(#[fail(cause)] std::io::Error),
+
+    #[fail(display = "{}", _0)]
+    Diagnostic(Diagnostic),
+
+    #[fail(display = "unexpected token")]
+    InvalidTokenType(LexicalToken, String),
+
+    #[fail(display = "unexpected token")]
+    UnexpectedToken(LexicalToken, Vec<String>),
+
+    #[fail(display = "unexpected eof")]
+    UnexpectedEOF,
+}
+impl PreprocessorError {
+    pub fn span(&self) -> Option<ByteSpan> {
+        match *self {
+            PreprocessorError::Lexical(ref err) => Some(err.span()),
+            PreprocessorError::ParseError(ref span, _) => Some(span.clone()),
+            PreprocessorError::CompilerError(Some(ref span), _) => Some(span.clone()),
+            PreprocessorError::InvalidConstExpression(ref span) => Some(span.clone()),
+            PreprocessorError::InvalidConditional(ref span) => Some(span.clone()),
+            PreprocessorError::BuiltinFailed(ref span, _) => Some(span.clone()),
+            PreprocessorError::OrphanedEnd(ref dir) => Some(dir.span()),
+            PreprocessorError::OrphanedElse(ref dir) => Some(dir.span()),
+            PreprocessorError::UndefinedStringifyMacro(ref m) => Some(m.span()),
+            PreprocessorError::UndefinedMacro(ref m) => Some(m.span()),
+            PreprocessorError::BadMacroCall(ref call, _, _) => Some(call.span()),
+            PreprocessorError::InvalidTokenType(ref t, _) => Some(t.span()),
+            PreprocessorError::UnexpectedToken(ref t, _) => Some(t.span()),
+            _ => None,
+        }
+    }
+
+    pub fn to_diagnostic(&self) -> Diagnostic {
+        let span = self.span();
+        let msg = self.to_string();
+        match *self {
+            PreprocessorError::Diagnostic(ref d) => d.clone(),
+            PreprocessorError::Lexical(ref err) => err.to_diagnostic(),
+            PreprocessorError::Source(ref err) => err.to_diagnostic(),
+            PreprocessorError::ParseError(_, ref errs) => {
+                let mut d = Diagnostic::new_error(msg)
+                    .with_label(Label::new_primary(span.unwrap())
+                        .with_message("invalid constant expression"));
+                for err in errs.iter() {
+                    let err = err.to_diagnostic();
+                    for label in err.labels {
+                        d = d.with_label(label);
+                    }
+                }
+                d
+            }
+            PreprocessorError::CompilerError(Some(_), _) =>
+                Diagnostic::new_error("found error directive")
+                    .with_label(Label::new_primary(span.unwrap())
+                        .with_message(msg)),
+            PreprocessorError::InvalidConstExpression(_) =>
+                Diagnostic::new_error(msg)
+                    .with_label(Label::new_primary(span.unwrap())
+                        .with_message("expected valid constant expression (example: `?OTP_VERSION >= 21`)")),
+            PreprocessorError::InvalidConditional(_) =>
+                Diagnostic::new_error(msg)
+                    .with_label(Label::new_primary(span.unwrap())
+                        .with_message("expected 'true', 'false', or an expression which can be evaluated to 'true' or 'false'")),
+            PreprocessorError::BuiltinFailed(_, ref cause) =>
+                Diagnostic::new_error(msg)
+                    .with_label(Label::new_primary(span.unwrap())
+                        .with_message(cause.to_string())),
+            PreprocessorError::BadMacroCall(_, MacroDef::String(_), ref reason) =>
+                Diagnostic::new_error(msg)
+                    .with_label(Label::new_primary(span.unwrap())
+                        .with_message(reason.to_owned())),
+            PreprocessorError::BadMacroCall(_, ref def, ref reason) => {
+                let d = Diagnostic::new_error(msg)
+                            .with_label(Label::new_primary(span.unwrap())
+                                .with_message("this macro call does not match its definition"));
+                let secondary_span = match def {
+                    MacroDef::Static(ref define) =>
+                        define.span(),
+                    MacroDef::Dynamic(ref tokens) => {
+                        assert!(tokens.len() > 0);
+                        ByteSpan::new(
+                            tokens[0].span().start(),
+                            tokens.last().unwrap().span().end()
+                        )
+                    },
+                    _ => unreachable!()
+                };
+                d.with_label(Label::new_secondary(secondary_span)
+                    .with_message(reason.to_owned()))
+            }
+            PreprocessorError::IO(_) =>
+                Diagnostic::new_error("i/o failed")
+                    .with_label(Label::new_primary(span.unwrap())
+                        .with_message(msg)),
+            PreprocessorError::InvalidTokenType(_, ref expected) =>
+                Diagnostic::new_error(msg)
+                    .with_label(Label::new_primary(span.unwrap())
+                        .with_message(format!("expected \"{}\"", expected))),
+            PreprocessorError::UnexpectedToken(_, ref expected) => {
+                if expected.len() > 0 {
+                    let expected = expected.iter()
+                        .map(|t| format!("\"{}\"", t))
+                        .join(", ");
+                    Diagnostic::new_error(msg)
+                        .with_label(Label::new_primary(span.unwrap())
+                            .with_message(format!("expected one of {}", expected)))
+                } else {
+                    Diagnostic::new_error(msg)
+                        .with_label(Label::new_primary(span.unwrap()))
+                }
+            }
+            _ if span.is_some() =>
+                Diagnostic::new_error("preprocessor error")
+                    .with_label(Label::new_primary(span.unwrap()).with_message(msg)),
+            _ =>
+                Diagnostic::new_error(format!("preprocessor error: {}", msg)),
+        }
+    }
+}
+impl From<LexicalError> for PreprocessorError {
+    fn from(err: LexicalError) -> PreprocessorError {
+        PreprocessorError::Lexical(err)
+    }
+}
+impl From<SourceError> for PreprocessorError {
+    fn from(err: SourceError) -> PreprocessorError {
+        PreprocessorError::Source(err)
+    }
+}
+impl From<TokenConvertError> for PreprocessorError {
+    fn from(err: TokenConvertError) -> PreprocessorError {
+        let span = err.span;
+        let token = LexicalToken(span.start(), err.token, span.end());
+        PreprocessorError::InvalidTokenType(token, err.expected.to_string())
+    }
+}
+impl From<std::io::Error> for PreprocessorError {
+    fn from(err: std::io::Error) -> Self {
+        PreprocessorError::IO(err)
+    }
+}
+impl From<glob::GlobError> for PreprocessorError {
+    fn from(err: glob::GlobError) -> Self {
+        PreprocessorError::Diagnostic(Diagnostic::new_error(err.to_string()))
+    }
+}
+impl From<glob::PatternError> for PreprocessorError {
+    fn from(err: glob::PatternError) -> Self {
+        PreprocessorError::Diagnostic(Diagnostic::new_error(err.to_string()))
+    }
+}

--- a/frontend/src/preprocessor/evaluator.rs
+++ b/frontend/src/preprocessor/evaluator.rs
@@ -1,0 +1,789 @@
+use failure::Error;
+use rug::Integer;
+
+use diagnostics::ByteSpan;
+
+use crate::lexer::{symbols, Ident, Symbol};
+use crate::parser::ast::*;
+
+use super::errors::PreprocessorError;
+
+/// This evaluator is used for performing simple reductions
+/// during preprocessing, namely for evaluating conditionals
+/// in -if/-elseif directives.
+///
+/// As a result, the output of this function is _not_ a primitive
+/// value, but rather an Expr which has been reduced to its simplest
+/// form (e.g. a BinaryOp that can be evaluated at compile-time would
+/// be converted into the corresponding literal representation of the
+/// result of that op)
+///
+/// Exprs which are not able to be evaluated at compile-time will be
+/// treated as errors. In particular the following constructs are supported,
+/// and you can consider everything else as invalid unless explicitly noted:
+///
+/// - Math on constants or expressions which evaluate to constants
+/// - Bit shift operations on constants or expressions which evaluate to constants
+/// - Comparisons on constants or expressions which evaluate to constants
+/// - The use of `++` and `--` on constant lists, or expressions which evaluate to constant lists
+pub fn eval(expr: Expr) -> Result<Expr, PreprocessorError> {
+    let result = match expr {
+        // Nothing to be done here
+        Expr::Var(_) => expr,
+        Expr::Literal(_) => expr,
+        Expr::Nil(_) => expr,
+        Expr::FunctionName(_) => expr,
+        Expr::RecordIndex(_) => expr,
+
+        // Recursively evaluate subexpressions
+        Expr::Cons(Cons {
+            span,
+            box head,
+            box tail,
+        }) => Expr::Cons(Cons {
+            span,
+            head: Box::new(eval(head)?),
+            tail: Box::new(eval(tail)?),
+        }),
+        Expr::Tuple(Tuple { span, elements }) => Expr::Tuple(Tuple {
+            span,
+            elements: eval_list(elements)?,
+        }),
+        Expr::Map(Map { span, fields }) => Expr::Map(Map {
+            span,
+            fields: eval_map(fields)?,
+        }),
+        Expr::MapUpdate(MapUpdate {
+            span,
+            map: box map,
+            updates,
+        }) => Expr::MapUpdate(MapUpdate {
+            span,
+            map: Box::new(eval(map)?),
+            updates: eval_map(updates)?,
+        }),
+        Expr::MapProjection(MapProjection {
+            span,
+            map: box map,
+            fields,
+        }) => Expr::MapProjection(MapProjection {
+            span,
+            map: Box::new(eval(map)?),
+            fields: eval_map(fields)?,
+        }),
+        Expr::Binary(Binary { span, elements }) => Expr::Binary(Binary {
+            span,
+            elements: eval_bin_elements(elements)?,
+        }),
+        Expr::Record(Record { span, name, fields }) => Expr::Record(Record {
+            span,
+            name,
+            fields: eval_record(fields)?,
+        }),
+        Expr::RecordAccess(RecordAccess {
+            span,
+            box record,
+            name,
+            field,
+        }) => Expr::RecordAccess(RecordAccess {
+            span,
+            record: Box::new(eval(record)?),
+            name,
+            field,
+        }),
+        Expr::RecordUpdate(RecordUpdate {
+            span,
+            box record,
+            name,
+            updates,
+        }) => Expr::RecordUpdate(RecordUpdate {
+            span,
+            record: Box::new(eval(record)?),
+            name,
+            updates: eval_record(updates)?,
+        }),
+        Expr::Begin(Begin { span, .. }) => {
+            return Err(PreprocessorError::InvalidConstExpression(span));
+        }
+        Expr::Apply(Apply {
+            span,
+            box callee,
+            args,
+        }) => {
+            let args = eval_list(args)?;
+            match eval(callee)? {
+                Expr::Literal(Literal::Atom(Ident { ref name, .. })) => match builtin(*name) {
+                    None => {
+                        return Err(PreprocessorError::InvalidConstExpression(span));
+                    }
+                    Some(fun) => match fun(args) {
+                        Err(err) => return Err(PreprocessorError::BuiltinFailed(span, err)),
+                        Ok(expr) => expr,
+                    },
+                },
+                _ => return Err(PreprocessorError::InvalidConstExpression(span)),
+            }
+        }
+        Expr::BinaryExpr(BinaryExpr {
+            span,
+            box lhs,
+            op,
+            box rhs,
+        }) => {
+            let lhs = eval(lhs)?;
+            let rhs = eval(rhs)?;
+            return eval_binary_op(span, lhs, op, rhs);
+        }
+        Expr::UnaryExpr(UnaryExpr {
+            span,
+            op,
+            box operand,
+        }) => {
+            let operand = eval(operand)?;
+            return eval_unary_op(span, op, operand);
+        }
+        expr => {
+            return Err(PreprocessorError::InvalidConstExpression(expr.span()));
+        }
+    };
+
+    Ok(result)
+}
+
+fn eval_list(mut exprs: Vec<Expr>) -> Result<Vec<Expr>, PreprocessorError> {
+    let mut result = Vec::new();
+
+    for expr in exprs.drain(..) {
+        result.push(eval(expr)?);
+    }
+
+    Ok(result)
+}
+
+fn eval_map(mut fields: Vec<MapField>) -> Result<Vec<MapField>, PreprocessorError> {
+    let mut result = Vec::new();
+
+    for field in fields.drain(..) {
+        match field {
+            MapField::Assoc { span, key, value } => result.push(MapField::Assoc {
+                span,
+                key: eval(key)?,
+                value: eval(value)?,
+            }),
+            MapField::Exact { span, key, value } => result.push(MapField::Exact {
+                span,
+                key: eval(key)?,
+                value: eval(value)?,
+            }),
+        }
+    }
+
+    Ok(result)
+}
+
+fn eval_record(mut fields: Vec<RecordField>) -> Result<Vec<RecordField>, PreprocessorError> {
+    let mut result = Vec::new();
+
+    for field in fields.drain(..) {
+        let new_field = match field {
+            RecordField {
+                span,
+                name,
+                value: Some(value),
+                ty,
+            } => RecordField {
+                span,
+                name,
+                value: Some(eval(value)?),
+                ty,
+            },
+            RecordField {
+                span,
+                name,
+                value: None,
+                ty,
+            } => RecordField {
+                span,
+                name,
+                value: None,
+                ty,
+            },
+        };
+        result.push(new_field);
+    }
+
+    Ok(result)
+}
+
+fn eval_bin_elements(
+    mut elements: Vec<BinaryElement>,
+) -> Result<Vec<BinaryElement>, PreprocessorError> {
+    let mut result = Vec::new();
+
+    for element in elements.drain(..) {
+        let new_element = match element {
+            BinaryElement {
+                span,
+                bit_expr,
+                bit_size: Some(bit_size),
+                bit_type,
+            } => BinaryElement {
+                span,
+                bit_expr: eval(bit_expr)?,
+                bit_size: Some(eval(bit_size)?),
+                bit_type,
+            },
+
+            BinaryElement {
+                span,
+                bit_expr,
+                bit_size: None,
+                bit_type,
+            } => BinaryElement {
+                span,
+                bit_expr: eval(bit_expr)?,
+                bit_size: None,
+                bit_type,
+            },
+        };
+
+        result.push(new_element);
+    }
+
+    Ok(result)
+}
+
+fn eval_binary_op(
+    span: ByteSpan,
+    lhs: Expr,
+    op: BinaryOp,
+    rhs: Expr,
+) -> Result<Expr, PreprocessorError> {
+    match op {
+        BinaryOp::OrElse | BinaryOp::AndAlso | BinaryOp::Or | BinaryOp::And => {
+            eval_boolean(span, lhs, op, rhs)
+        }
+        BinaryOp::Equal | BinaryOp::NotEqual => eval_equality(span, lhs, op, rhs),
+        BinaryOp::StrictEqual | BinaryOp::StrictNotEqual => {
+            eval_strict_equality(span, lhs, op, rhs)
+        }
+        BinaryOp::Lte | BinaryOp::Lt | BinaryOp::Gte | BinaryOp::Gt => {
+            eval_comparison(span, lhs, op, rhs)
+        }
+        BinaryOp::Add
+        | BinaryOp::Sub
+        | BinaryOp::Multiply
+        | BinaryOp::Divide
+        | BinaryOp::Div
+        | BinaryOp::Rem => eval_arith(span, lhs, op, rhs),
+        BinaryOp::Bor
+        | BinaryOp::Bxor
+        | BinaryOp::Xor
+        | BinaryOp::Band
+        | BinaryOp::Bsl
+        | BinaryOp::Bsr => eval_shift(span, lhs, op, rhs),
+        _ => return Err(PreprocessorError::InvalidConstExpression(span)),
+    }
+}
+
+fn eval_unary_op(span: ByteSpan, op: UnaryOp, rhs: Expr) -> Result<Expr, PreprocessorError> {
+    let expr = match op {
+        UnaryOp::Plus => match rhs {
+            Expr::Literal(Literal::Integer(span, i)) if i < 0 => {
+                Expr::Literal(Literal::Integer(span, i * -1))
+            }
+            Expr::Literal(Literal::Integer(_, _)) => rhs,
+            Expr::Literal(Literal::BigInteger(span, i)) => {
+                if i < 0 {
+                    Expr::Literal(Literal::BigInteger(span, i * -1))
+                } else {
+                    Expr::Literal(Literal::BigInteger(span, i))
+                }
+            }
+            Expr::Literal(Literal::Float(span, i)) if i < 0.0 => {
+                Expr::Literal(Literal::Float(span, i * -1.0))
+            }
+            Expr::Literal(Literal::Float(_, _)) => rhs,
+            _ => return Err(PreprocessorError::InvalidConstExpression(span)),
+        },
+        UnaryOp::Minus => match rhs {
+            Expr::Literal(Literal::Integer(span, i)) if i > 0 => {
+                Expr::Literal(Literal::Integer(span, i * -1))
+            }
+            Expr::Literal(Literal::Integer(_, _)) => rhs,
+            Expr::Literal(Literal::BigInteger(span, i)) => {
+                if i > 0 {
+                    Expr::Literal(Literal::BigInteger(span, i * -1))
+                } else {
+                    Expr::Literal(Literal::BigInteger(span, i))
+                }
+            }
+            Expr::Literal(Literal::Float(span, i)) if i > 0.0 => {
+                Expr::Literal(Literal::Float(span, i * -1.0))
+            }
+            Expr::Literal(Literal::Float(_, _)) => rhs,
+            _ => return Err(PreprocessorError::InvalidConstExpression(span)),
+        },
+        UnaryOp::Bnot => match rhs {
+            Expr::Literal(Literal::Integer(span, i)) => Expr::Literal(Literal::Integer(span, !i)),
+            Expr::Literal(Literal::BigInteger(span, i)) => {
+                Expr::Literal(Literal::BigInteger(span, !i))
+            }
+            _ => return Err(PreprocessorError::InvalidConstExpression(span)),
+        },
+        UnaryOp::Not => match rhs {
+            Expr::Literal(Literal::Atom(Ident { name, span })) if name == symbols::True => {
+                Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::False,
+                    span,
+                }))
+            }
+            Expr::Literal(Literal::Atom(Ident { name, span })) if name == symbols::False => {
+                Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::True,
+                    span,
+                }))
+            }
+            _ => return Err(PreprocessorError::InvalidConstExpression(span)),
+        },
+    };
+    Ok(expr)
+}
+
+fn eval_boolean(
+    span: ByteSpan,
+    lhs: Expr,
+    op: BinaryOp,
+    rhs: Expr,
+) -> Result<Expr, PreprocessorError> {
+    if !is_boolean(&lhs) || !is_boolean(&rhs) {
+        return Err(PreprocessorError::InvalidConstExpression(span));
+    }
+    let left = is_true(&lhs);
+    let right = is_true(&rhs);
+
+    match op {
+        BinaryOp::Xor => {
+            if (left != right) && (left || right) {
+                return Ok(Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::True,
+                    span,
+                })));
+            }
+            return Ok(Expr::Literal(Literal::Atom(Ident {
+                name: symbols::False,
+                span,
+            })));
+        }
+        BinaryOp::OrElse | BinaryOp::Or => {
+            if left || right {
+                return Ok(Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::True,
+                    span,
+                })));
+            } else {
+                return Ok(Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::False,
+                    span,
+                })));
+            }
+        }
+        BinaryOp::AndAlso | BinaryOp::And => {
+            if left && right {
+                return Ok(Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::True,
+                    span,
+                })));
+            } else {
+                return Ok(Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::False,
+                    span,
+                })));
+            }
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn eval_equality(
+    span: ByteSpan,
+    lhs: Expr,
+    op: BinaryOp,
+    rhs: Expr,
+) -> Result<Expr, PreprocessorError> {
+    if is_number(&lhs) && is_number(&rhs) {
+        eval_numeric_equality(span, lhs, op, rhs)
+    } else {
+        match op {
+            BinaryOp::Equal => {
+                if lhs == rhs {
+                    Ok(Expr::Literal(Literal::Atom(Ident {
+                        name: symbols::True,
+                        span,
+                    })))
+                } else {
+                    Ok(Expr::Literal(Literal::Atom(Ident {
+                        name: symbols::False,
+                        span,
+                    })))
+                }
+            }
+            BinaryOp::NotEqual => {
+                if lhs != rhs {
+                    Ok(Expr::Literal(Literal::Atom(Ident {
+                        name: symbols::True,
+                        span,
+                    })))
+                } else {
+                    Ok(Expr::Literal(Literal::Atom(Ident {
+                        name: symbols::False,
+                        span,
+                    })))
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+fn eval_strict_equality(
+    span: ByteSpan,
+    lhs: Expr,
+    op: BinaryOp,
+    rhs: Expr,
+) -> Result<Expr, PreprocessorError> {
+    match op {
+        BinaryOp::StrictEqual => {
+            if lhs == rhs {
+                Ok(Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::True,
+                    span,
+                })))
+            } else {
+                Ok(Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::False,
+                    span,
+                })))
+            }
+        }
+        BinaryOp::StrictNotEqual => {
+            if lhs != rhs {
+                Ok(Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::True,
+                    span,
+                })))
+            } else {
+                Ok(Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::False,
+                    span,
+                })))
+            }
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn eval_numeric_equality(
+    span: ByteSpan,
+    lhs: Expr,
+    op: BinaryOp,
+    rhs: Expr,
+) -> Result<Expr, PreprocessorError> {
+    let result = match (lhs, rhs) {
+        (Expr::Literal(Literal::Integer(_, x)), Expr::Literal(Literal::Integer(_, y))) => {
+            match op {
+                BinaryOp::Equal if x == y => Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::True,
+                    span,
+                })),
+                BinaryOp::NotEqual if x != y => Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::True,
+                    span,
+                })),
+                BinaryOp::Equal => Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::False,
+                    span,
+                })),
+                BinaryOp::NotEqual => Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::False,
+                    span,
+                })),
+                _ => unreachable!(),
+            }
+        }
+        (Expr::Literal(Literal::BigInteger(_, x)), Expr::Literal(Literal::BigInteger(_, y))) => {
+            match op {
+                BinaryOp::Equal if x == y => Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::True,
+                    span,
+                })),
+                BinaryOp::NotEqual if x != y => Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::True,
+                    span,
+                })),
+                BinaryOp::Equal => Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::False,
+                    span,
+                })),
+                BinaryOp::NotEqual => Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::False,
+                    span,
+                })),
+                _ => unreachable!(),
+            }
+        }
+        (Expr::Literal(Literal::Float(_, x)), Expr::Literal(Literal::Float(_, y))) => match op {
+            BinaryOp::Equal if x == y => Expr::Literal(Literal::Atom(Ident {
+                name: symbols::True,
+                span,
+            })),
+            BinaryOp::NotEqual if x != y => Expr::Literal(Literal::Atom(Ident {
+                name: symbols::True,
+                span,
+            })),
+            BinaryOp::Equal => Expr::Literal(Literal::Atom(Ident {
+                name: symbols::False,
+                span,
+            })),
+            BinaryOp::NotEqual => Expr::Literal(Literal::Atom(Ident {
+                name: symbols::False,
+                span,
+            })),
+            _ => unreachable!(),
+        },
+        (
+            Expr::Literal(Literal::Integer(xspan, x)),
+            rhs @ Expr::Literal(Literal::BigInteger(_, _)),
+        ) => {
+            return eval_numeric_equality(
+                span,
+                Expr::Literal(Literal::BigInteger(xspan, Integer::from(x))),
+                op,
+                rhs,
+            );
+        }
+
+        (Expr::Literal(Literal::Integer(xspan, x)), rhs @ Expr::Literal(Literal::Float(_, _))) => {
+            return eval_numeric_equality(
+                span,
+                Expr::Literal(Literal::Float(xspan, x as f64)),
+                op,
+                rhs,
+            );
+        }
+
+        (
+            lhs @ Expr::Literal(Literal::BigInteger(_, _)),
+            Expr::Literal(Literal::Integer(yspan, y)),
+        ) => {
+            return eval_numeric_equality(
+                span,
+                lhs,
+                op,
+                Expr::Literal(Literal::BigInteger(yspan, Integer::from(y))),
+            );
+        }
+
+        (lhs @ Expr::Literal(Literal::Float(_, _)), Expr::Literal(Literal::Integer(yspan, y))) => {
+            return eval_numeric_equality(
+                span,
+                lhs,
+                op,
+                Expr::Literal(Literal::Float(yspan, y as f64)),
+            );
+        }
+
+        _ => return Err(PreprocessorError::InvalidConstExpression(span)),
+    };
+
+    Ok(result)
+}
+
+fn eval_comparison(
+    span: ByteSpan,
+    lhs: Expr,
+    op: BinaryOp,
+    rhs: Expr,
+) -> Result<Expr, PreprocessorError> {
+    match op {
+        BinaryOp::Lt | BinaryOp::Lte => {
+            if lhs < rhs {
+                Ok(Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::True,
+                    span,
+                })))
+            } else if op == BinaryOp::Lte {
+                eval_equality(span, lhs, BinaryOp::Equal, rhs)
+            } else {
+                Ok(Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::False,
+                    span,
+                })))
+            }
+        }
+        BinaryOp::Gt | BinaryOp::Gte => {
+            if lhs > rhs {
+                Ok(Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::True,
+                    span,
+                })))
+            } else if op == BinaryOp::Gte {
+                eval_equality(span, lhs, BinaryOp::Equal, rhs)
+            } else {
+                Ok(Expr::Literal(Literal::Atom(Ident {
+                    name: symbols::False,
+                    span,
+                })))
+            }
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn eval_arith(
+    span: ByteSpan,
+    lhs: Expr,
+    op: BinaryOp,
+    rhs: Expr,
+) -> Result<Expr, PreprocessorError> {
+    if is_number(&lhs) && is_number(&rhs) {
+        let result = match (lhs, rhs) {
+            // Types match
+            (Expr::Literal(Literal::Integer(_, x)), Expr::Literal(Literal::Integer(_, y))) => {
+                eval_op_int(span, x, op, y)?
+            }
+            (
+                Expr::Literal(Literal::BigInteger(_, x)),
+                Expr::Literal(Literal::BigInteger(_, y)),
+            ) => eval_op_bigint(span, x, op, y)?,
+            (Expr::Literal(Literal::Float(_, x)), Expr::Literal(Literal::Float(_, y))) => {
+                eval_op_float(span, x, op, y)?
+            }
+
+            // Coerce to BigInt
+            (Expr::Literal(Literal::Integer(_, x)), Expr::Literal(Literal::BigInteger(_, y))) => {
+                eval_op_bigint(span, Integer::from(x), op, y)?
+            }
+            (Expr::Literal(Literal::BigInteger(_, x)), Expr::Literal(Literal::Integer(_, y))) => {
+                eval_op_bigint(span, x, op, Integer::from(y))?
+            }
+
+            // Coerce to float
+            (Expr::Literal(Literal::Integer(_, x)), Expr::Literal(Literal::Float(_, y))) => {
+                eval_op_float(span, x as f64, op, y)?
+            }
+            (Expr::Literal(Literal::Float(_, x)), Expr::Literal(Literal::Integer(_, y))) => {
+                eval_op_float(span, x, op, y as f64)?
+            }
+
+            _ => return Err(PreprocessorError::InvalidConstExpression(span)),
+        };
+        Ok(result)
+    } else {
+        return Err(PreprocessorError::InvalidConstExpression(span));
+    }
+}
+
+fn eval_op_int(span: ByteSpan, x: i64, op: BinaryOp, y: i64) -> Result<Expr, PreprocessorError> {
+    let result = match op {
+        BinaryOp::Add => Expr::Literal(Literal::Integer(span, x + y)),
+        BinaryOp::Sub => Expr::Literal(Literal::Integer(span, x - y)),
+        BinaryOp::Multiply => Expr::Literal(Literal::Integer(span, x * y)),
+        BinaryOp::Divide if y == 0 => return Err(PreprocessorError::InvalidConstExpression(span)),
+        BinaryOp::Divide => Expr::Literal(Literal::Float(span, (x as f64) / (y as f64))),
+        BinaryOp::Div if y == 0 => return Err(PreprocessorError::InvalidConstExpression(span)),
+        BinaryOp::Div => Expr::Literal(Literal::Integer(span, x / y)),
+        BinaryOp::Rem => Expr::Literal(Literal::Integer(span, x % y)),
+        _ => unreachable!(),
+    };
+    Ok(result)
+}
+
+fn eval_op_bigint(
+    span: ByteSpan,
+    x: Integer,
+    op: BinaryOp,
+    y: Integer,
+) -> Result<Expr, PreprocessorError> {
+    let zero = Integer::new();
+    let result = match op {
+        BinaryOp::Add => Expr::Literal(Literal::BigInteger(span, x + y)),
+        BinaryOp::Sub => Expr::Literal(Literal::BigInteger(span, x - y)),
+        BinaryOp::Multiply => Expr::Literal(Literal::BigInteger(span, x * y)),
+        BinaryOp::Divide => return Err(PreprocessorError::InvalidConstExpression(span)),
+        BinaryOp::Div if y == zero => return Err(PreprocessorError::InvalidConstExpression(span)),
+        BinaryOp::Div => Expr::Literal(Literal::BigInteger(span, x / y)),
+        BinaryOp::Rem => Expr::Literal(Literal::BigInteger(span, x % y)),
+        _ => unreachable!(),
+    };
+    Ok(result)
+}
+
+fn eval_op_float(span: ByteSpan, x: f64, op: BinaryOp, y: f64) -> Result<Expr, PreprocessorError> {
+    match op {
+        BinaryOp::Add => Ok(Expr::Literal(Literal::Float(span, x + y))),
+        BinaryOp::Sub => Ok(Expr::Literal(Literal::Float(span, x - y))),
+        BinaryOp::Multiply => Ok(Expr::Literal(Literal::Float(span, x * y))),
+        BinaryOp::Divide if y == 0.0 => {
+            return Err(PreprocessorError::InvalidConstExpression(span))
+        }
+        BinaryOp::Divide => Ok(Expr::Literal(Literal::Float(span, x / y))),
+        BinaryOp::Div => return Err(PreprocessorError::InvalidConstExpression(span)),
+        BinaryOp::Rem => return Err(PreprocessorError::InvalidConstExpression(span)),
+        _ => unreachable!(),
+    }
+}
+
+fn eval_shift(
+    span: ByteSpan,
+    lhs: Expr,
+    op: BinaryOp,
+    rhs: Expr,
+) -> Result<Expr, PreprocessorError> {
+    match (lhs, rhs) {
+        (Expr::Literal(Literal::Integer(_, x)), Expr::Literal(Literal::Integer(_, y))) => {
+            let result = match op {
+                BinaryOp::Bor => Expr::Literal(Literal::Integer(span, x | y)),
+                BinaryOp::Bxor => Expr::Literal(Literal::Integer(span, x ^ y)),
+                BinaryOp::Band => Expr::Literal(Literal::Integer(span, x & y)),
+                BinaryOp::Bsl => Expr::Literal(Literal::Integer(span, x << y)),
+                BinaryOp::Bsr => Expr::Literal(Literal::Integer(span, x >> y)),
+                _ => unreachable!(),
+            };
+            Ok(result)
+        }
+        _ => return Err(PreprocessorError::InvalidConstExpression(span)),
+    }
+}
+
+fn is_number(e: &Expr) -> bool {
+    match *e {
+        Expr::Literal(Literal::Integer(_, _)) => true,
+        Expr::Literal(Literal::BigInteger(_, _)) => true,
+        Expr::Literal(Literal::Float(_, _)) => true,
+        _ => false,
+    }
+}
+
+fn is_boolean(e: &Expr) -> bool {
+    match *e {
+        Expr::Literal(Literal::Atom(Ident { ref name, .. })) => {
+            if *name == symbols::True || *name == symbols::False {
+                return true;
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+fn is_true(e: &Expr) -> bool {
+    match *e {
+        Expr::Literal(Literal::Atom(Ident { ref name, .. })) if *name == symbols::True => true,
+        _ => false,
+    }
+}
+
+fn builtin(_name: Symbol) -> Option<&'static fn(Vec<Expr>) -> Result<Expr, Error>> {
+    None
+}

--- a/frontend/src/preprocessor/macros.rs
+++ b/frontend/src/preprocessor/macros.rs
@@ -1,0 +1,127 @@
+use std::fmt;
+
+use diagnostics::ByteSpan;
+
+use crate::lexer::{IdentToken, SymbolToken};
+use crate::lexer::{LexicalToken, Symbol, Token};
+
+use super::directives::Define;
+use super::token_reader::{ReadFrom, TokenReader};
+use super::types::{MacroArgs, MacroName};
+use super::Result;
+
+/// Macro Definition.
+#[derive(Debug, Clone)]
+pub enum MacroDef {
+    Boolean(bool),
+    String(Symbol),
+    Static(Define),
+    Dynamic(Vec<LexicalToken>),
+}
+impl MacroDef {
+    /// Returns `true` if this macro has variables, otherwise `false`.
+    pub fn has_variables(&self) -> bool {
+        match *self {
+            MacroDef::Static(ref d) => d.variables.is_some(),
+            MacroDef::Dynamic(_) => false,
+            MacroDef::String(_) => false,
+            MacroDef::Boolean(_) => false,
+        }
+    }
+}
+
+/// Macro call.
+#[derive(Debug, Clone)]
+pub struct MacroCall {
+    pub _question: SymbolToken,
+    pub name: MacroName,
+    pub args: Option<MacroArgs>,
+}
+impl MacroCall {
+    pub fn span(&self) -> ByteSpan {
+        let start = self._question.0;
+        let end = self
+            .args
+            .as_ref()
+            .map(|a| a.span().end())
+            .unwrap_or_else(|| self.name.span().end());
+        ByteSpan::new(start, end)
+    }
+
+    pub fn name(&self) -> Symbol {
+        self.name.symbol()
+    }
+}
+impl fmt::Display for MacroCall {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "?{}{}",
+            self.name.symbol(),
+            self.args.as_ref().map_or("".to_string(), |a| a.to_string())
+        )
+    }
+}
+impl ReadFrom for MacroCall {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        Ok(MacroCall {
+            _question: reader.read_expected(&Token::Question)?,
+            name: reader.read()?,
+            args: reader.try_read()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NoArgsMacroCall {
+    pub _question: SymbolToken,
+    pub name: MacroName,
+}
+impl NoArgsMacroCall {
+    pub fn span(&self) -> ByteSpan {
+        ByteSpan::new(self._question.span().start(), self.name.span().end())
+    }
+}
+impl ReadFrom for NoArgsMacroCall {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        Ok(NoArgsMacroCall {
+            _question: reader.read_expected(&Token::Question)?,
+            name: reader.read()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Stringify {
+    pub _double_question: SymbolToken,
+    pub name: IdentToken,
+}
+impl Stringify {
+    pub fn span(&self) -> ByteSpan {
+        let start = self._double_question.0;
+        let end = self.name.2;
+        ByteSpan::new(start, end)
+    }
+}
+impl fmt::Display for Stringify {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "??{}", self.name)
+    }
+}
+impl ReadFrom for Stringify {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        Ok(Stringify {
+            _double_question: reader.read_expected(&Token::DoubleQuestion)?,
+            name: reader.read()?,
+        })
+    }
+}

--- a/frontend/src/preprocessor/preprocessor.rs
+++ b/frontend/src/preprocessor/preprocessor.rs
@@ -1,0 +1,431 @@
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::convert::TryFrom;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use failure::{format_err, Error};
+use termcolor::ColorChoice;
+
+use diagnostics::{ByteIndex, ByteSpan, CodeMap, Diagnostic, Label};
+use diagnostics::{Emitter, StandardStreamEmitter};
+
+use crate::lexer::{symbols, IdentToken, Lexed, LexicalToken, Symbol, Token};
+use crate::lexer::{Lexer, Source};
+use crate::parser::ParseConfig;
+
+use super::macros::Stringify;
+use super::token_reader::{TokenBufferReader, TokenReader, TokenStreamReader};
+use super::{Directive, MacroCall, MacroDef};
+use super::{Preprocessed, PreprocessorError, Result};
+
+pub struct Preprocessor<Reader: TokenReader> {
+    codemap: Arc<Mutex<CodeMap>>,
+    reader: Reader,
+    can_directive_start: bool,
+    directives: BTreeMap<ByteIndex, Directive>,
+    code_paths: VecDeque<PathBuf>,
+    branches: Vec<Branch>,
+    macros: HashMap<Symbol, MacroDef>,
+    macro_calls: BTreeMap<ByteIndex, MacroCall>,
+    expanded_tokens: VecDeque<LexicalToken>,
+    warnings_as_errors: bool,
+    no_warn: bool,
+}
+impl<S> Preprocessor<TokenStreamReader<S>>
+where
+    S: Source,
+{
+    pub fn new(config: &ParseConfig, tokens: Lexer<S>) -> Self {
+        let codemap = config.codemap.clone();
+        let reader = TokenStreamReader::new(codemap.clone(), tokens);
+        let code_paths = config.code_paths.clone();
+        let macros = match config.macros {
+            None => HashMap::new(),
+            Some(ref macros) => macros.clone(),
+        };
+        Preprocessor {
+            codemap,
+            reader,
+            can_directive_start: true,
+            directives: BTreeMap::new(),
+            code_paths,
+            branches: Vec::new(),
+            macros,
+            macro_calls: BTreeMap::new(),
+            expanded_tokens: VecDeque::new(),
+            warnings_as_errors: config.warnings_as_errors,
+            no_warn: config.no_warn,
+        }
+    }
+}
+impl<R, S> Preprocessor<R>
+where
+    R: TokenReader<Source = S>,
+{
+    fn clone_with(&self, tokens: VecDeque<Lexed>) -> Preprocessor<TokenBufferReader> {
+        let codemap = self.codemap.clone();
+        let reader = TokenBufferReader::new(codemap.clone(), tokens);
+        Preprocessor {
+            codemap,
+            reader,
+            can_directive_start: false,
+            directives: BTreeMap::new(),
+            code_paths: self.code_paths.clone(),
+            branches: Vec::new(),
+            macros: self.macros.clone(),
+            macro_calls: BTreeMap::new(),
+            expanded_tokens: VecDeque::new(),
+            warnings_as_errors: self.warnings_as_errors,
+            no_warn: self.no_warn,
+        }
+    }
+
+    fn ignore(&self) -> bool {
+        self.branches.iter().any(|b| !b.entered)
+    }
+
+    fn next_token(&mut self) -> Result<Option<LexicalToken>> {
+        loop {
+            if let Some(token) = self.expanded_tokens.pop_front() {
+                return Ok(Some(token));
+            }
+            if self.can_directive_start {
+                match self.try_read_directive()? {
+                    Some(Directive::Module(d)) => {
+                        // We need to expand this directive back to a token stream for the parser
+                        self.expanded_tokens = d.expand();
+                        // Otherwise treat it like other directives
+                        self.directives
+                            .insert(d.span().start(), Directive::Module(d));
+                        continue;
+                    }
+                    Some(d) => {
+                        self.directives.insert(d.span().start(), d);
+                        continue;
+                    }
+                    None => (),
+                }
+            }
+            if !self.ignore() {
+                if let Some(m) = self.reader.try_read_macro_call(&self.macros)? {
+                    self.macro_calls.insert(m.span().start(), m.clone());
+                    self.expanded_tokens = self.expand_macro(m)?;
+                    continue;
+                }
+            }
+            if let Some(token) = self.reader.try_read_token()? {
+                if self.ignore() {
+                    continue;
+                }
+                if let LexicalToken(_, Token::Dot, _) = token {
+                    self.can_directive_start = true;
+                } else {
+                    self.can_directive_start = false;
+                }
+                return Ok(Some(token));
+            } else {
+                break;
+            }
+        }
+        Ok(None)
+    }
+
+    fn expand_macro(&self, call: MacroCall) -> Result<VecDeque<LexicalToken>> {
+        if let Some(expanded) = self.try_expand_predefined_macro(&call)? {
+            Ok(vec![expanded].into())
+        } else {
+            self.expand_userdefined_macro(call)
+        }
+    }
+
+    fn try_expand_predefined_macro(&self, call: &MacroCall) -> Result<Option<LexicalToken>> {
+        let expanded = match call.name().as_str().get() {
+            "FILE" => {
+                let span = call.span();
+                let current = span.start();
+                let filename = {
+                    self.codemap
+                        .lock()
+                        .unwrap()
+                        .find_file(current)
+                        .unwrap()
+                        .name()
+                        .clone()
+                };
+                LexicalToken(
+                    current,
+                    Token::String(Symbol::intern(&filename.to_string())),
+                    span.end(),
+                )
+            }
+            "LINE" => {
+                let span = call.span();
+                let current = span.start();
+                let line = {
+                    self.codemap
+                        .lock()
+                        .unwrap()
+                        .find_file(current)
+                        .unwrap()
+                        .find_line(current)
+                        .unwrap()
+                };
+                let line = line.to_usize() as i64;
+                LexicalToken(current, Token::Integer(line), span.end())
+            }
+            "MACHINE" => {
+                let span = call.span();
+                let current = span.start();
+                LexicalToken(current, Token::Atom(Symbol::intern("Lumen")), span.end())
+            }
+            _ => return Ok(None),
+        };
+        Ok(Some(expanded))
+    }
+
+    fn expand_userdefined_macro(&self, call: MacroCall) -> Result<VecDeque<LexicalToken>> {
+        let definition = match self.macros.get(&call.name()) {
+            None => return Err(PreprocessorError::UndefinedMacro(call)),
+            Some(def) => def,
+        };
+        match *definition {
+            MacroDef::Dynamic(ref replacement) => Ok(replacement.clone().into()),
+            MacroDef::String(ref s) => Ok(vec![LexicalToken(
+                ByteIndex(0),
+                Token::String(s.clone()),
+                ByteIndex(0),
+            )]
+            .into()),
+            MacroDef::Boolean(true) => Ok(vec![LexicalToken(
+                ByteIndex(0),
+                Token::Atom(symbols::True),
+                ByteIndex(0),
+            )]
+            .into()),
+            MacroDef::Boolean(false) => Ok(VecDeque::new()),
+            MacroDef::Static(ref def) => {
+                let arity = def.variables.as_ref().map(|v| v.len()).unwrap_or(0);
+                let argc = call.args.as_ref().map(|a| a.len()).unwrap_or(0);
+                if arity != argc {
+                    let err = format!(
+                        "expected {} arguments at call site, but given {}",
+                        arity, argc
+                    );
+                    return Err(PreprocessorError::BadMacroCall(
+                        call,
+                        definition.clone(),
+                        err,
+                    ));
+                }
+                let bindings = def
+                    .variables
+                    .as_ref()
+                    .iter()
+                    .flat_map(|i| i.iter().map(|v| v.symbol()))
+                    .zip(
+                        call.args
+                            .iter()
+                            .flat_map(|i| i.iter().map(|a| &a.tokens[..])),
+                    )
+                    .collect::<HashMap<_, _>>();
+                let expanded = self.expand_replacement(bindings, &def.replacement)?;
+                Ok(expanded)
+            }
+        }
+    }
+
+    fn expand_replacement(
+        &self,
+        bindings: HashMap<Symbol, &[LexicalToken]>,
+        replacement: &[LexicalToken],
+    ) -> Result<VecDeque<LexicalToken>> {
+        let mut expanded = VecDeque::new();
+        let replacement_tokens: VecDeque<_> = replacement.iter().map(|t| Ok(t.clone())).collect();
+        let mut reader = TokenBufferReader::new(self.codemap.clone(), replacement_tokens);
+
+        loop {
+            if let Some(call) = reader.try_read_macro_call(&self.macros)? {
+                let nested = self.expand_macro(call)?;
+                for token in nested.into_iter().rev() {
+                    reader.unread_token(token);
+                }
+            } else if let Some(stringify) = reader.try_read::<Stringify>()? {
+                let tokens = match bindings.get(&stringify.name.symbol()) {
+                    None => return Err(PreprocessorError::UndefinedStringifyMacro(stringify)),
+                    Some(tokens) => tokens,
+                };
+                let string = tokens.iter().map(|t| t.to_string()).collect::<String>();
+                let span = tokens[0].span();
+                let start = span.start();
+                let end = span.end();
+                let token = (start, Token::String(Symbol::intern(&string)), end);
+                expanded.push_back(token.into());
+            } else if let Some(token) = reader.try_read_token()? {
+                match IdentToken::try_from(token.clone()) {
+                    Ok(ident) => match bindings.get(&ident.symbol()) {
+                        Some(value) => {
+                            let nested = self.expand_replacement(HashMap::new(), value)?;
+                            expanded.extend(nested);
+                            continue;
+                        }
+                        None => (),
+                    },
+                    Err(_) => (),
+                }
+                expanded.push_back(token);
+            } else {
+                break;
+            }
+        }
+        Ok(expanded)
+    }
+
+    fn try_read_directive(&mut self) -> Result<Option<Directive>> {
+        let directive: Directive = if let Some(directive) = self.reader.try_read()? {
+            directive
+        } else {
+            return Ok(None);
+        };
+
+        let ignore = self.ignore();
+        match directive {
+            Directive::Module(ref d) => {
+                self.macros
+                    .insert(symbols::Module, MacroDef::String(d.name.symbol()));
+            }
+            Directive::Include(ref d) if !ignore => {
+                let path = d.include();
+                self.reader.inject_include(path)?;
+            }
+            Directive::IncludeLib(ref d) if !ignore => {
+                let path = d.include_lib(&self.code_paths)?;
+                self.reader.inject_include(path)?;
+            }
+            Directive::Define(ref d) if !ignore => {
+                self.macros
+                    .insert(d.name.symbol(), MacroDef::Static(d.clone()));
+            }
+            Directive::Undef(ref d) if !ignore => {
+                self.macros.remove(&d.name());
+            }
+            Directive::Ifdef(ref d) => {
+                let entered = self.macros.contains_key(&d.name());
+                self.branches.push(Branch::new(entered));
+            }
+            Directive::If(ref d) => {
+                let entered = self.eval_conditional(d.span(), d.condition.clone())?;
+                self.branches.push(Branch::new(entered));
+            }
+            Directive::Ifndef(ref d) => {
+                let entered = !self.macros.contains_key(&d.name());
+                self.branches.push(Branch::new(entered));
+            }
+            Directive::Else(_) => match self.branches.last_mut() {
+                None => return Err(PreprocessorError::OrphanedElse(directive)),
+                Some(branch) => {
+                    match branch.switch_to_else_branch() {
+                        Err(_) => return Err(PreprocessorError::OrphanedElse(directive)),
+                        Ok(_) => (),
+                    };
+                }
+            },
+            Directive::Elif(ref d) => {
+                // Treat this like -endif followed by -if(Cond)
+                match self.branches.pop() {
+                    None => return Err(PreprocessorError::OrphanedElse(directive)),
+                    Some(_) => {
+                        let entered = self.eval_conditional(d.span(), d.condition.clone())?;
+                        self.branches.push(Branch::new(entered));
+                    }
+                }
+            }
+            Directive::Endif(_) => match self.branches.pop() {
+                None => return Err(PreprocessorError::OrphanedEnd(directive)),
+                Some(_) => (),
+            },
+            Directive::Error(ref d) if !ignore => {
+                let span = d.span();
+                let err = d.message.symbol().as_str().get().to_string();
+                return Err(PreprocessorError::CompilerError(Some(span), err));
+            }
+            Directive::Warning(ref d) if !ignore => {
+                if self.no_warn {
+                    return Ok(Some(directive));
+                }
+                if self.warnings_as_errors {
+                    let span = d.span();
+                    let err = d.message.symbol().as_str().get().to_string();
+                    return Err(PreprocessorError::CompilerError(Some(span), err));
+                }
+                let span = d.span();
+                let warn = d.message.symbol().as_str().get();
+                let diag = Diagnostic::new_warning("found warning directive")
+                    .with_label(Label::new_primary(span).with_message(warn));
+                let emitter =
+                    StandardStreamEmitter::new(ColorChoice::Auto).set_codemap(self.codemap.clone());
+                emitter.diagnostic(&diag).unwrap();
+            }
+            _ => {}
+        }
+        Ok(Some(directive))
+    }
+
+    fn eval_conditional(&self, span: ByteSpan, condition: VecDeque<Lexed>) -> Result<bool> {
+        use crate::lexer::Ident;
+        use crate::parser::ast::{Expr, Literal};
+        use crate::parser::Parse;
+        use crate::preprocessor::evaluator;
+
+        let pp = self.clone_with(condition);
+        let result = <Expr as Parse<Expr>>::parse_tokens(pp);
+        match result {
+            Ok(expr) => match evaluator::eval(expr)? {
+                Expr::Literal(Literal::Atom(Ident { ref name, .. })) if *name == symbols::True => {
+                    Ok(true)
+                }
+                Expr::Literal(Literal::Atom(Ident { ref name, .. })) if *name == symbols::False => {
+                    Ok(false)
+                }
+                _other => return Err(PreprocessorError::InvalidConditional(span)),
+            },
+            Err(errs) => return Err(PreprocessorError::ParseError(span, errs)),
+        }
+    }
+}
+
+impl<R, S> Iterator for Preprocessor<R>
+where
+    R: TokenReader<Source = S>,
+{
+    type Item = Preprocessed;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.next_token() {
+            Err(e) => Some(Err(e)),
+            Ok(None) => None,
+            Ok(Some(token)) => Some(Ok(token.into())),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Branch {
+    pub then_branch: bool,
+    pub entered: bool,
+}
+impl Branch {
+    pub fn new(entered: bool) -> Self {
+        Branch {
+            then_branch: true,
+            entered,
+        }
+    }
+    pub fn switch_to_else_branch(&mut self) -> std::result::Result<(), Error> {
+        if !self.then_branch {
+            return Err(format_err!("orphaned else"));
+        }
+        self.then_branch = false;
+        self.entered = !self.entered;
+        Ok(())
+    }
+}

--- a/frontend/src/preprocessor/token_reader.rs
+++ b/frontend/src/preprocessor/token_reader.rs
@@ -1,0 +1,298 @@
+use std::collections::{HashMap, VecDeque};
+use std::convert::TryFrom;
+use std::fmt::Display;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use diagnostics::CodeMap;
+
+use crate::lexer::{AtomToken, SymbolToken, TokenConvertError};
+use crate::lexer::{FileMapSource, Scanner, Source};
+use crate::lexer::{Lexed, Lexer, LexicalToken, Symbol, Token};
+
+use super::macros::NoArgsMacroCall;
+use super::token_stream::TokenStream;
+use super::{MacroCall, MacroDef, PreprocessorError, Result};
+
+pub trait TokenReader: Sized {
+    type Source;
+
+    fn new(codemap: Arc<Mutex<CodeMap>>, tokens: Self::Source) -> Self;
+
+    fn inject_include<P>(&mut self, path: P) -> Result<()>
+    where
+        P: AsRef<Path>;
+
+    fn read<V: ReadFrom>(&mut self) -> Result<V> {
+        V::read_from(self)
+    }
+
+    fn try_read<V: ReadFrom>(&mut self) -> Result<Option<V>> {
+        V::try_read_from(self)
+    }
+
+    fn try_read_macro_call(
+        &mut self,
+        macros: &HashMap<Symbol, MacroDef>,
+    ) -> Result<Option<MacroCall>> {
+        if let Some(call) = self.try_read::<NoArgsMacroCall>()? {
+            let span = call.span();
+            let start = span.start();
+            let mut call = MacroCall {
+                _question: SymbolToken(start, Token::Question, start),
+                name: call.name,
+                args: None,
+            };
+            if macros
+                .get(&call.name())
+                .map_or(false, |m| m.has_variables())
+            {
+                call.args = Some(self.read()?);
+            }
+            Ok(Some(call))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn read_expected<V>(&mut self, expected: &V::Value) -> Result<V>
+    where
+        V: ReadFrom + Expect + Into<LexicalToken>,
+    {
+        V::read_expected(self, expected)
+    }
+
+    fn try_read_expected<V>(&mut self, expected: &V::Value) -> Result<Option<V>>
+    where
+        V: ReadFrom + Expect + Into<LexicalToken>,
+    {
+        V::try_read_expected(self, expected)
+    }
+
+    fn try_read_token(&mut self) -> Result<Option<LexicalToken>>;
+
+    fn read_token(&mut self) -> Result<LexicalToken>;
+
+    fn unread_token(&mut self, token: LexicalToken);
+}
+
+/// Reads tokens from an in-memory buffer (VecDeque)
+pub struct TokenBufferReader {
+    codemap: Arc<Mutex<CodeMap>>,
+    tokens: VecDeque<Lexed>,
+    unread: VecDeque<LexicalToken>,
+}
+impl TokenReader for TokenBufferReader {
+    type Source = VecDeque<Lexed>;
+
+    fn new(codemap: Arc<Mutex<CodeMap>>, tokens: Self::Source) -> Self {
+        TokenBufferReader {
+            codemap: codemap.clone(),
+            tokens,
+            unread: VecDeque::new(),
+        }
+    }
+
+    // Adds tokens from the provided path
+    fn inject_include<P>(&mut self, path: P) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        let source = FileMapSource::from_path(self.codemap.clone(), path)?;
+        let scanner = Scanner::new(source);
+        let lexer = Lexer::new(scanner);
+        let mut tokens: VecDeque<Lexed> = lexer.collect();
+        tokens.append(&mut self.tokens);
+        self.tokens = tokens;
+        Ok(())
+    }
+
+    fn try_read_token(&mut self) -> Result<Option<LexicalToken>> {
+        if let Some(token) = self.unread.pop_front() {
+            return Ok(Some(token));
+        }
+        match self.tokens.pop_front() {
+            None => Ok(None),
+            Some(Err(e)) => Err(e.into()),
+            Some(Ok(t)) => Ok(Some(t)),
+        }
+    }
+
+    fn read_token(&mut self) -> Result<LexicalToken> {
+        if let Some(token) = self.try_read_token()? {
+            Ok(token)
+        } else {
+            Err(PreprocessorError::UnexpectedEOF)
+        }
+    }
+
+    fn unread_token(&mut self, token: LexicalToken) {
+        self.unread.push_front(token);
+    }
+}
+
+/// Reads tokens from a TokenStream (backed by a Lexer)
+pub struct TokenStreamReader<S> {
+    codemap: Arc<Mutex<CodeMap>>,
+    tokens: TokenStream<S>,
+    unread: VecDeque<LexicalToken>,
+}
+impl<S> TokenReader for TokenStreamReader<S>
+where
+    S: Source,
+{
+    type Source = Lexer<S>;
+
+    fn new(codemap: Arc<Mutex<CodeMap>>, tokens: Self::Source) -> Self {
+        TokenStreamReader {
+            codemap: codemap.clone(),
+            tokens: TokenStream::new(tokens),
+            unread: VecDeque::new(),
+        }
+    }
+
+    // Adds tokens from the provided path
+    fn inject_include<P>(&mut self, path: P) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        let source = Source::from_path(self.codemap.clone(), path)?;
+        let scanner = Scanner::new(source);
+        let lexer = Lexer::new(scanner);
+        self.tokens.include(lexer);
+        Ok(())
+    }
+
+    fn try_read_token(&mut self) -> Result<Option<LexicalToken>> {
+        if let Some(token) = self.unread.pop_front() {
+            return Ok(Some(token));
+        }
+        match self.tokens.next() {
+            None => Ok(None),
+            Some(Err(e)) => Err(e.into()),
+            Some(Ok(t)) => Ok(Some(t)),
+        }
+    }
+
+    fn read_token(&mut self) -> Result<LexicalToken> {
+        if let Some(token) = self.try_read_token()? {
+            Ok(token)
+        } else {
+            Err(PreprocessorError::UnexpectedEOF)
+        }
+    }
+
+    fn unread_token(&mut self, token: LexicalToken) {
+        self.unread.push_front(token);
+    }
+}
+
+pub trait ReadFrom: Sized {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        let directive = Self::try_read_from(reader)?;
+        Ok(directive.unwrap())
+    }
+
+    fn try_read_from<R, S>(reader: &mut R) -> Result<Option<Self>>
+    where
+        R: TokenReader<Source = S>,
+    {
+        Self::read_from(reader).map(Some).or_else(|e| match e {
+            PreprocessorError::UnexpectedToken(token, _) => {
+                reader.unread_token(token.clone());
+                return Ok(None);
+            }
+            PreprocessorError::InvalidTokenType(token, _) => {
+                reader.unread_token(token.clone());
+                return Ok(None);
+            }
+            PreprocessorError::UnexpectedEOF => {
+                return Ok(None);
+            }
+            _ => Err(e),
+        })
+    }
+
+    fn read_expected<R, S>(reader: &mut R, expected: &Self::Value) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+        Self: Expect + Into<LexicalToken>,
+    {
+        Self::read_from(reader)
+            .map_err(|err| match err {
+                PreprocessorError::UnexpectedToken(token, _) => {
+                    PreprocessorError::UnexpectedToken(token, vec![expected.to_string()])
+                }
+                PreprocessorError::InvalidTokenType(token, _) => {
+                    PreprocessorError::InvalidTokenType(token, expected.to_string())
+                }
+                _ => err,
+            })
+            .and_then(|token| {
+                if token.expect(expected) {
+                    Ok(token)
+                } else {
+                    Err(PreprocessorError::UnexpectedToken(
+                        token.into(),
+                        vec![expected.to_string()],
+                    ))
+                }
+            })
+    }
+
+    fn try_read_expected<R, S>(reader: &mut R, expected: &Self::Value) -> Result<Option<Self>>
+    where
+        R: TokenReader<Source = S>,
+        Self: Expect + Into<LexicalToken>,
+    {
+        Self::try_read_from(reader).map(|token| {
+            token.and_then(|token| {
+                if token.expect(expected) {
+                    Some(token)
+                } else {
+                    reader.unread_token(token.into());
+                    None
+                }
+            })
+        })
+    }
+}
+
+/// Default implementation for all TryFrom<LexicalToken> supporting types
+impl<T> ReadFrom for T
+where
+    T: TryFrom<LexicalToken, Error = TokenConvertError>,
+{
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        let token = reader.read_token()?;
+        Self::try_from(token).map_err(PreprocessorError::from)
+    }
+}
+
+pub trait Expect {
+    type Value: PartialEq + Display + ?Sized;
+
+    fn expect(&self, expected: &Self::Value) -> bool;
+}
+
+impl Expect for AtomToken {
+    type Value = Symbol;
+
+    fn expect(&self, expected: &Self::Value) -> bool {
+        self.symbol() == *expected
+    }
+}
+
+impl Expect for SymbolToken {
+    type Value = Token;
+
+    fn expect(&self, expected: &Self::Value) -> bool {
+        expected.eq(&self.token())
+    }
+}

--- a/frontend/src/preprocessor/token_stream.rs
+++ b/frontend/src/preprocessor/token_stream.rs
@@ -1,0 +1,54 @@
+use std::collections::VecDeque;
+
+use crate::lexer::{Lexed, Lexer, Source};
+
+pub struct TokenStream<S> {
+    eof: bool,
+    current: Lexer<S>,
+    streams: VecDeque<Lexer<S>>,
+}
+impl<S> TokenStream<S>
+where
+    S: Source,
+{
+    pub fn new(current: Lexer<S>) -> Self {
+        TokenStream {
+            eof: false,
+            current,
+            streams: VecDeque::new(),
+        }
+    }
+
+    pub fn include(&mut self, next: Lexer<S>) {
+        if self.eof {
+            self.eof = false;
+        }
+        let previous = std::mem::replace::<Lexer<S>>(&mut self.current, next);
+        self.streams.push_front(previous);
+    }
+}
+impl<S> Iterator for TokenStream<S>
+where
+    S: Source,
+{
+    type Item = Lexed;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.eof == true {
+            return None;
+        }
+        if let Some(next) = self.current.next() {
+            return Some(next);
+        }
+        match self.streams.pop_front() {
+            None => {
+                self.eof = true;
+                return None;
+            }
+            Some(next) => {
+                self.current = next;
+                return self.next();
+            }
+        }
+    }
+}

--- a/frontend/src/preprocessor/types.rs
+++ b/frontend/src/preprocessor/types.rs
@@ -1,0 +1,344 @@
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::mem;
+
+use diagnostics::ByteSpan;
+
+use crate::lexer::{AtomToken, IdentToken, SymbolToken};
+use crate::lexer::{LexicalToken, Symbol, Token};
+
+use super::token_reader::{ReadFrom, TokenReader};
+use super::{PreprocessorError, Result};
+
+/// The list of tokens that can be used as a macro name.
+#[derive(Debug, Clone)]
+pub enum MacroName {
+    Atom(AtomToken),
+    Variable(IdentToken),
+}
+impl MacroName {
+    /// Returns the value of this token.
+    pub fn value(&self) -> Token {
+        match *self {
+            MacroName::Atom(ref token) => token.token(),
+            MacroName::Variable(ref token) => token.token(),
+        }
+    }
+
+    /// Returns the original textual representation of this token.
+    pub fn symbol(&self) -> Symbol {
+        match *self {
+            MacroName::Atom(ref token) => token.symbol(),
+            MacroName::Variable(ref token) => token.symbol(),
+        }
+    }
+
+    pub fn span(&self) -> ByteSpan {
+        match *self {
+            MacroName::Atom(ref token) => token.span(),
+            MacroName::Variable(ref token) => token.span(),
+        }
+    }
+}
+impl PartialEq for MacroName {
+    fn eq(&self, other: &Self) -> bool {
+        self.value() == other.value()
+    }
+}
+impl Hash for MacroName {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.value().hash(hasher);
+    }
+}
+impl fmt::Display for MacroName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.symbol())
+    }
+}
+impl ReadFrom for MacroName {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        if let Some(token) = reader.try_read()? {
+            Ok(MacroName::Atom(token))
+        } else {
+            let token = reader.read()?;
+            Ok(MacroName::Variable(token))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MacroVariables {
+    pub _open_paren: SymbolToken,
+    pub list: List<IdentToken>,
+    pub _close_paren: SymbolToken,
+}
+impl MacroVariables {
+    /// Returns an iterator which iterates over this variables.
+    pub fn iter(&self) -> ListIter<IdentToken> {
+        self.list.iter()
+    }
+
+    /// Returns the number of this variables.
+    pub fn len(&self) -> usize {
+        self.list.iter().count()
+    }
+
+    /// Returns `true` if there are no variables.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn span(&self) -> ByteSpan {
+        ByteSpan::new(self._open_paren.0, self._close_paren.2)
+    }
+}
+impl fmt::Display for MacroVariables {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({})", self.list)
+    }
+}
+impl ReadFrom for MacroVariables {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        Ok(MacroVariables {
+            _open_paren: reader.read_expected(&Token::LParen)?,
+            list: reader.read()?,
+            _close_paren: reader.read_expected(&Token::RParen)?,
+        })
+    }
+}
+
+/// Macro arguments.
+#[derive(Debug, Clone)]
+pub struct MacroArgs {
+    pub _open_paren: SymbolToken,
+    pub list: List<MacroArg>,
+    pub _close_paren: SymbolToken,
+}
+impl MacroArgs {
+    /// Returns an iterator which iterates over this arguments.
+    pub fn iter(&self) -> ListIter<MacroArg> {
+        self.list.iter()
+    }
+
+    /// Returns the number of this arguments.
+    pub fn len(&self) -> usize {
+        self.list.iter().count()
+    }
+
+    /// Returns `true` if there are no arguments.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn span(&self) -> ByteSpan {
+        ByteSpan::new(self._open_paren.0, self._close_paren.2)
+    }
+}
+impl fmt::Display for MacroArgs {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({})", self.list)
+    }
+}
+impl ReadFrom for MacroArgs {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        Ok(MacroArgs {
+            _open_paren: reader.read_expected(&Token::LParen)?,
+            list: reader.read()?,
+            _close_paren: reader.read_expected(&Token::RParen)?,
+        })
+    }
+}
+
+/// Macro argument.
+#[derive(Debug, Clone)]
+pub struct MacroArg {
+    /// Tokens which represent a macro argument.
+    ///
+    /// Note that this must not be empty.
+    pub tokens: Vec<LexicalToken>,
+}
+impl MacroArg {
+    pub fn span(&self) -> ByteSpan {
+        let start = self.tokens.first().unwrap().span().start();
+        let end = self.tokens.last().unwrap().span().end();
+        ByteSpan::new(start, end)
+    }
+}
+impl fmt::Display for MacroArg {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for t in &self.tokens {
+            write!(f, "{}", t)?;
+        }
+        Ok(())
+    }
+}
+impl ReadFrom for MacroArg {
+    fn try_read_from<R, S>(reader: &mut R) -> Result<Option<Self>>
+    where
+        R: TokenReader<Source = S>,
+    {
+        let mut stack = Vec::new();
+        let mut arg = Vec::new();
+        while let Some(ref token @ LexicalToken(_, _, _)) = reader.try_read_token()? {
+            match token.1 {
+                Token::RParen if stack.is_empty() => {
+                    reader.unread_token(token.clone().into());
+                    return if arg.is_empty() {
+                        Ok(None)
+                    } else {
+                        Ok(Some(MacroArg { tokens: arg }))
+                    };
+                }
+                Token::Comma if stack.is_empty() => {
+                    if arg.len() == 0 {
+                        return Err(PreprocessorError::UnexpectedToken(token.clone(), vec![]));
+                    }
+                    reader.unread_token(token.clone().into());
+                    return Ok(Some(MacroArg { tokens: arg }));
+                }
+                Token::LParen | Token::LBrace | Token::LBracket | Token::BinaryStart => {
+                    stack.push(token.clone());
+                }
+                Token::RParen | Token::RBrace | Token::RBracket | Token::BinaryEnd => {
+                    match stack.pop() {
+                        None => (),
+                        Some(LexicalToken(_, t2, _)) => {
+                            if token.1 == t2 {
+                                continue;
+                            }
+                        }
+                    }
+                    let expected = vec![
+                        Token::RParen,
+                        Token::RBrace,
+                        Token::RBracket,
+                        Token::BinaryEnd,
+                    ]
+                    .iter()
+                    .map(|t| t.to_string())
+                    .collect();
+                    return Err(PreprocessorError::UnexpectedToken(token.clone(), expected));
+                }
+                _ => (),
+            }
+            arg.push(token.clone());
+        }
+        Err(PreprocessorError::UnexpectedEOF)
+    }
+}
+
+/// Tail part of a linked list (cons cell).
+#[derive(Debug, Clone)]
+pub enum Tail<T> {
+    Nil,
+    Cons {
+        _comma: SymbolToken,
+        head: T,
+        tail: Box<Tail<T>>,
+    },
+}
+impl<T: fmt::Display> fmt::Display for Tail<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Tail::Nil => Ok(()),
+            Tail::Cons {
+                ref head, ref tail, ..
+            } => write!(f, ",{}{}", head, tail),
+        }
+    }
+}
+impl<U: ReadFrom> ReadFrom for Tail<U> {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        if let Some(_comma) = reader.try_read_expected(&Token::Comma)? {
+            let head = reader.read()?;
+            let tail = Box::new(reader.read()?);
+            Ok(Tail::Cons { _comma, head, tail })
+        } else {
+            Ok(Tail::Nil)
+        }
+    }
+}
+
+/// Linked list (cons cell).
+#[derive(Debug, Clone)]
+#[allow(missing_docs)]
+pub enum List<T> {
+    Nil,
+    Cons { head: T, tail: Tail<T> },
+}
+impl<T> List<T> {
+    /// Returns an iterator which iterates over the elements in this list.
+    pub fn iter(&self) -> ListIter<T> {
+        ListIter(ListIterInner::List(self))
+    }
+}
+impl<T: fmt::Display> fmt::Display for List<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            List::Nil => Ok(()),
+            List::Cons { ref head, ref tail } => write!(f, "{}{}", head, tail),
+        }
+    }
+}
+impl<U: ReadFrom> ReadFrom for List<U> {
+    fn read_from<R, S>(reader: &mut R) -> Result<Self>
+    where
+        R: TokenReader<Source = S>,
+    {
+        if let Some(head) = reader.try_read()? {
+            let tail = reader.read()?;
+            Ok(List::Cons { head, tail })
+        } else {
+            Ok(List::Nil)
+        }
+    }
+}
+
+/// An iterator which iterates over the elements in a `List`.
+#[derive(Debug)]
+pub struct ListIter<'a, T: 'a>(ListIterInner<'a, T>);
+impl<'a, T: 'a> Iterator for ListIter<'a, T> {
+    type Item = &'a T;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+#[derive(Debug)]
+enum ListIterInner<'a, T: 'a> {
+    List(&'a List<T>),
+    Tail(&'a Tail<T>),
+    End,
+}
+impl<'a, T: 'a> Iterator for ListIterInner<'a, T> {
+    type Item = &'a T;
+    fn next(&mut self) -> Option<Self::Item> {
+        match mem::replace(self, ListIterInner::End) {
+            ListIterInner::List(&List::Cons { ref head, ref tail }) => {
+                *self = ListIterInner::Tail(tail);
+                Some(head)
+            }
+            ListIterInner::Tail(&Tail::Cons {
+                ref head, ref tail, ..
+            }) => {
+                *self = ListIterInner::Tail(tail);
+                Some(head)
+            }
+            ListIterInner::List(&List::Nil)
+            | ListIterInner::Tail(&Tail::Nil)
+            | ListIterInner::End => None,
+        }
+    }
+}

--- a/frontend/src/util.rs
+++ b/frontend/src/util.rs
@@ -1,0 +1,25 @@
+use crate::lexer::SourceError;
+use std::env;
+use std::path::{Path, PathBuf};
+
+pub fn substitute_path_variables<P: AsRef<Path>>(path: P) -> Result<PathBuf, SourceError> {
+    let mut new = PathBuf::new();
+    for c in path.as_ref().components() {
+        if let Some(s) = c.as_os_str().to_str() {
+            if s.as_bytes().get(0) == Some(&b'$') {
+                let var = s.split_at(1).1;
+                match env::var(var) {
+                    Ok(c) => {
+                        new.push(c);
+                        continue;
+                    }
+                    Err(e) => {
+                        return Err(SourceError::InvalidEnvironmentVariable(e, var.to_owned()));
+                    }
+                }
+            }
+        }
+        new.push(c.as_os_str());
+    }
+    Ok(new)
+}


### PR DESCRIPTION
This is the entirety of the Erlang frontend from Lumen, unfortunately I couldn't find a way to bring over the history, but we still have it in Lumen if needed for reference:

- Provides a diagnostics library for debug info and source spans
- Provides an Erlang frontend/parser built on LALRPOP
    - Supports all valid Erlang syntax
    - Supports all standard attributes (e.g. compiler directives,
    typespecs/callbacks, etc.)
    - Supports preprocessor directives/macro expansion

NOTE: This **does not** support parse transforms (yet). That is a
difficult topic, since it requires evaluation of Erlang source code.
While the preprocessor supports some degree of partial evaluation, it is
limited to the things supported in preprocessor directives, whereas
parse transforms require support for significantly more functionality,
possibly the full language.

I chose the names `diagnostics` and `frontend`, but in my opinion we should reorganize this project's crates a bit, and provide some namespaced names instead. This will make it easier to publish individual crates, as well as provide some guidance on naming. I'll open a separate issue with my thoughts on that, just know that for now these are the names I've chosen, though I think they are not the names we ultimately want.