### PR TITLE
Fix use of Eir repo as dependency

### DIFF
--- a/cps_transform/Cargo.toml
+++ b/cps_transform/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Hans Elias B. Josephsen <me@hansihe.com>"]
 edition = "2018"
 
 [dependencies]
-eir = { path = "../eir" }
-util = { path = "../util" }
+#eir = { path = "../eir" }
+libeir_util = { path = "../libeir_util" }
 
 petgraph = "0.4.13"
 cranelift-entity = "0.30.0"

--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -18,6 +18,6 @@ pretty = "0.3.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
-core_erlang_compiler = { path = "../compiler" }
-eir = { path = "../eir" }
+#core_erlang_compiler = { path = "../compiler" }
+#eir = { path = "../eir" }
 


### PR DESCRIPTION
Cargo explodes when trying to pull in `libeir_ir` due to an issue in the `interpreter` Cargo manifest, I suppose because it walks the tree of manifests, but I couldn't find how it was pulling in that crate specifically. In any case, the fix is to simply comment out/fixup the non-existent dependencies until they get updated.