### PR TITLE
Map BinaryOp::Or and And to matching erlang word name, not symbolic name

### DIFF
--- a/libeir_syntax_erl/src/lower/expr/binary_expr.rs
+++ b/libeir_syntax_erl/src/lower/expr/binary_expr.rs
@@ -101,7 +101,7 @@ pub(super) fn lower_binary_expr(ctx: &mut LowerCtx, b: &mut FunctionBuilder, mut
                 BinaryOp::Bsl => (Ident::from_str("erlang"), Ident::from_str("bsl")),
                 BinaryOp::Bsr => (Ident::from_str("erlang"), Ident::from_str("bsr")),
                 BinaryOp::Or => (Ident::from_str("erlang"), Ident::from_str("or")),
-                BinaryOp::And => (Ident::from_str("erlang"), Ident::from_str("&")),
+                BinaryOp::And => (Ident::from_str("erlang"), Ident::from_str("and")),
                 BinaryOp::Send => (Ident::from_str("erlang"), Ident::from_str("!")),
                 _ => unimplemented!("{:?}", op),
             };

--- a/libeir_syntax_erl/src/lower/expr/binary_expr.rs
+++ b/libeir_syntax_erl/src/lower/expr/binary_expr.rs
@@ -100,7 +100,7 @@ pub(super) fn lower_binary_expr(ctx: &mut LowerCtx, b: &mut FunctionBuilder, mut
                 BinaryOp::Bor => (Ident::from_str("erlang"), Ident::from_str("bor")),
                 BinaryOp::Bsl => (Ident::from_str("erlang"), Ident::from_str("bsl")),
                 BinaryOp::Bsr => (Ident::from_str("erlang"), Ident::from_str("bsr")),
-                BinaryOp::Or => (Ident::from_str("erlang"), Ident::from_str("|")),
+                BinaryOp::Or => (Ident::from_str("erlang"), Ident::from_str("or")),
                 BinaryOp::And => (Ident::from_str("erlang"), Ident::from_str("&")),
                 BinaryOp::Send => (Ident::from_str("erlang"), Ident::from_str("!")),
                 _ => unimplemented!("{:?}", op),


### PR DESCRIPTION
While writing integration tests for `liblumen_otp`, I was having errors that `and` mapped to an unknown `_erlang:&/2` and `or` mapped to an unknown `_erlang:|/2`.  Checking that I didn't miss `&` or `|` in `erlang`, I tried to `TAB` completing them with `erlang.` in `iex` and couldn't find them while I can find the `send` alias `!`.  Going further, I tried `apply(:erlang, :&, [true, true])` and `apply(:erlang, :|, [true, true])` and they both raised `UndefinedFunctionError`, while `:and` and `:or` work as expected.  Did I miss something @hansihe?

# Changelog
## Bug Fixes
* Map `BinaryOp::Or` to `erlang:or/2` instead of `erlang:|/2`.
* Map `BinaryOp::And` to `erlang:and/2` instad of `erlang:&/2`.

